### PR TITLE
Use outside motion sensor for lux input

### DIFF
--- a/packages/living_room_lights.yaml
+++ b/packages/living_room_lights.yaml
@@ -13,10 +13,8 @@ automation:
   - alias: Living Room motion - sunlight timeout
     trigger:
       - platform: numeric_state
-        entity_id: sensor.sunlight_pct
-        above: 15
-        for:
-          minutes: 30
+        entity_id: sensor.outside_utility_room_lightlevel
+        below: 300
     action:
       service: homeassistant.turn_off
       entity_id: light.sofa_overhead, light.dining_table_overhead, light.uplighter, light.sideboard


### PR DESCRIPTION
Dark Sky is useless for cloud coverage in winter. Bright blue skies for miles around, and it's apparently 80% cloud coverage