### PR TITLE
Fix more irritations caused by home-assistant enforcing an rfxcom migration to unintelligible names.

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -158,7 +158,7 @@ study_lighting:
     - light.study
     - light.monitor_lights
 
-    hall:
+hall:
   name: Hall lights
   entities:
     - light.hall_bathroom

--- a/groups.yaml
+++ b/groups.yaml
@@ -152,7 +152,13 @@ craft_room_lighting:
     - light.craft_room
     - light.craft_room_fairy_lights
 
-hall:
+study_lighting:
+  name: Study Lights
+  entities:
+    - light.study
+    - light.monitor_lights
+
+    hall:
   name: Hall lights
   entities:
     - light.hall_bathroom

--- a/lights.yaml
+++ b/lights.yaml
@@ -38,6 +38,10 @@
   name: "Lava Lamp"
   entity_id: switch.lightwaverf_siemens_f0dd3c_15
 
+- platform: switch
+  name: "Monitor Lights"
+  entity_id: switch.monitor_lights
+
 - platform: group
   name: Decking Lights
   entities:

--- a/lights.yaml
+++ b/lights.yaml
@@ -32,11 +32,11 @@
 
 - platform: switch
   name: "Craft Room Fairy Lights"
-  entity_id: switch.lightwaverf_siemens_f0dd3c_10
+  entity_id: switch.craft_fairy_lights
 
 - platform: switch
   name: "Lava Lamp"
-  entity_id: switch.lightwaverf_siemens_f0dd3c_15
+  entity_id: switch.lava_lamp
 
 - platform: switch
   name: "Monitor Lights"

--- a/packages/study_lights.yaml
+++ b/packages/study_lights.yaml
@@ -8,7 +8,7 @@ automation:
       - service: switch.turn_on
         entity_id: switch.study_switch_relay
       - service: light.toggle
-        entity_id: light.study_light
+        entity_id: group.study_lighting
       - service: logbook.log
         data_template:
           name: EVENT


### PR DESCRIPTION
Fix more irritations caused by home-assistant enforcing an rfxcom migration to unintelligible names.