### PR TITLE
Create average external light level

### DIFF
--- a/automation/TimedTriggers/turn_off_bedside_lights.yaml
+++ b/automation/TimedTriggers/turn_off_bedside_lights.yaml
@@ -1,9 +1,8 @@
 alias: "Off wakup lights"
 trigger:
   - platform: numeric_state
-    entity_id: sensor.outside_utility_room_lightlevel
-    #above: 500 # Too high for middle of winter
-    above: 150
+    entity_id: sensor.average_external_light_level
+    above: 500
 action:
   - service: light.turn_off
     data:

--- a/automation/kitchen_motion.yaml
+++ b/automation/kitchen_motion.yaml
@@ -5,8 +5,8 @@ trigger:
   to: 'on'
 condition:
   - condition: numeric_state
-    entity_id: sensor.outside_utility_room_lightlevel
-    below: 750
+    entity_id: sensor.average_external_light_level
+    below: 1000
 action:
   - service: homeassistant.turn_on
     data_template:

--- a/automation/media_playing_night.yaml
+++ b/automation/media_playing_night.yaml
@@ -10,8 +10,8 @@ trigger:
     to: "playing"
 condition:
   - condition: numeric_state
-    entity_id: sensor.outside_utility_room_lightlevel
-    below: 750
+    entity_id: sensor.average_external_light_level
+    below: 1000
   - condition: state
     entity_id: binary_sensor.kitchen_motion
     state: "off"

--- a/automation/media_stopped_night.yaml
+++ b/automation/media_stopped_night.yaml
@@ -13,8 +13,8 @@ trigger:
     to: "paused"
 condition:
   - condition: numeric_state
-    entity_id: sensor.outside_utility_room_lightlevel
-    below: 750
+    entity_id: sensor.average_external_light_level
+    below: 1000
 action:
   - service: light.turn_on
     data:

--- a/automation/utility_room_door_open.yaml
+++ b/automation/utility_room_door_open.yaml
@@ -10,8 +10,8 @@ trigger:
     from: 'off'
 condition:
   - condition: numeric_state
-    entity_id: sensor.outside_utility_room_lightlevel
-    below: 750
+    entity_id: sensor.average_external_light_level
+    below: 1000
 action:
   - service: homeassistant.turn_on
     data_template:

--- a/packages/boot_room.yaml
+++ b/packages/boot_room.yaml
@@ -30,8 +30,8 @@ automation:
         entity_id: input_boolean.night_view
         state: "off"
       - condition: numeric_state
-        entity_id: sensor.outside_utility_room_lightlevel
-        below: 750
+        entity_id: sensor.average_external_light_level
+        below: 1000
     action:
       - service: light.turn_on
         data_template:
@@ -64,8 +64,8 @@ automation:
   - alias: Boot Room motion - sunlight timeout
     trigger:
       - platform: numeric_state
-        entity_id: sensor.outside_utility_room_lightlevel
-        above: 750
+        entity_id: sensor.average_external_light_level
+        above: 1000
     action:
       service: homeassistant.turn_off
       entity_id: light.boot_room
@@ -85,8 +85,8 @@ automation:
         entity_id: input_boolean.night_view
         state: "on"
       - condition: numeric_state
-        entity_id: sensor.outside_utility_room_lightlevel
-        below: 750
+        entity_id: sensor.average_external_light_level
+        below: 1000
     action:
       - service: light.turn_on
         data_template:

--- a/packages/cheerlights.yaml
+++ b/packages/cheerlights.yaml
@@ -23,7 +23,7 @@ automation:
       topic: cheerlightsRGB
     condition:
       - condition: numeric_state
-        entity_id: sensor.outside_utility_room_lightlevel
+        entity_id: sensor.average_external_light_level
         below: 300
       - condition: time
         after: '16:00:00'

--- a/packages/christmas_lights.yaml
+++ b/packages/christmas_lights.yaml
@@ -25,8 +25,8 @@ automation:
   - alias: Outside decorations - on evening
     trigger:
       - platform: numeric_state
-        entity_id: sensor.outside_utility_room_lightlevel
-        below: 100
+        entity_id: sensor.average_external_light_level
+        below: 500
     condition:
       - condition: state
         entity_id: binary_sensor.christmastime
@@ -78,8 +78,8 @@ automation:
       - platform: time
         at: "12:00:00"
       - platform: numeric_state
-        entity_id: sensor.outside_utility_room_lightlevel
-        above: 100
+        entity_id: sensor.average_external_light_level
+        above: 500
     action:
       - service: homeassistant.turn_off
         entity_id: light.outside_decorations

--- a/packages/ensuite.yaml
+++ b/packages/ensuite.yaml
@@ -94,8 +94,8 @@ automation:
         above: 10
     condition:
       - condition: numeric_state
-        entity_id: sensor.outside_utility_room_lightlevel
-        below: 750
+        entity_id: sensor.average_external_light_level
+        below: 1000
     action:
       - service: light.turn_on
         data_template:

--- a/packages/hallway.yaml
+++ b/packages/hallway.yaml
@@ -57,8 +57,8 @@ automation:
         to: 'on'
     condition:
       - condition: numeric_state
-        entity_id: sensor.outside_utility_room_lightlevel
-        below: 750
+        entity_id: sensor.average_external_light_level
+        below: 1000
     action:
       - service: light.turn_on
         data_template:

--- a/packages/living_room_lights.yaml
+++ b/packages/living_room_lights.yaml
@@ -57,8 +57,8 @@ automation:
   - alias: Living Room motion - sunlight timeout
     trigger:
       - platform: numeric_state
-        entity_id: sensor.outside_utility_room_lightlevel
-        above: 750
+        entity_id: sensor.average_external_light_level
+        above: 1000
     action:
       service: homeassistant.turn_off
       entity_id: light.sofa_overhead, light.dining_table_overhead, light.uplighter, light.sideboard, light.train_cabinets, light.dining_nook
@@ -75,8 +75,8 @@ automation:
         entity_id: input_boolean.night_view
         state: "off"
       - condition: numeric_state
-        entity_id: sensor.outside_utility_room_lightlevel
-        below: 750
+        entity_id: sensor.average_external_light_level
+        below: 1000
       - condition: or
         conditions:
           - condition: state

--- a/sensors.yaml
+++ b/sensors.yaml
@@ -124,6 +124,14 @@
     - battery.voltage
 
 - platform: min_max
+  name: Average External Light Level
+  type: median
+  entity_ids:
+    - sensor.lux_meter_1_level
+    - sensor.lux_meter_2_level
+    - sensor.lux_meter_3_level
+
+- platform: min_max
   name: House Average Temperature
   type: mean
   entity_ids:


### PR DESCRIPTION
Uses three window mounted light level meters to average surrounding light levels, based on east, west and south views