### PR TITLE
Use status_led light platform instead of status_led component

### DIFF
--- a/esphome/common/sonoff_basic_switch_common.yaml
+++ b/esphome/common/sonoff_basic_switch_common.yaml
@@ -32,7 +32,7 @@ switch:
     pin: GPIO12
     id: relay
 
-status_led:
-  pin:
-    number: GPIO13
-    inverted: yes
+light:
+  - platform: status_led
+    name: "Status LED"
+    pin: GPIO13


### PR DESCRIPTION
Apparently the status_led component causes issues with wifi connections on the Sonoff Basic. 