### PR TITLE
Run a dummy ESPHome job unless a real one is required

### DIFF
--- a/.github/workflows/esphome-dummy.yaml
+++ b/.github/workflows/esphome-dummy.yaml
@@ -1,0 +1,24 @@
+---
+name: ESPHome
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    paths-ignore:
+      - 'esphome/**'
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'esphome/**'
+  schedule:
+    - cron: 0 12 * * *
+
+jobs:
+  # This is used by branch protections
+  final:
+    name: Final ESPHome check
+    runs-on: ubuntu-latest
+    needs: [loop-stable, loop-beta, loop-dev]
+    steps:
+      - name: Getting your configuration from GitHub
+        uses: actions/checkout@v2

--- a/.github/workflows/esphome-dummy.yaml
+++ b/.github/workflows/esphome-dummy.yaml
@@ -1,6 +1,8 @@
 ---
 name: ESPHome
 
+## This workflow exists to keep branch protection happy in the event of no changes being made to the esphome directory.
+
 # yamllint disable-line rule:truthy
 on:
   pull_request:

--- a/.github/workflows/esphome-dummy.yaml
+++ b/.github/workflows/esphome-dummy.yaml
@@ -18,7 +18,5 @@ jobs:
   final:
     name: Final ESPHome check
     runs-on: ubuntu-latest
-    needs: [loop-stable, loop-beta, loop-dev]
     steps:
-      - name: Getting your configuration from GitHub
-        uses: actions/checkout@v2
+      - run: 'echo "No build required"'

--- a/.github/workflows/esphome-parallel.yaml
+++ b/.github/workflows/esphome-parallel.yaml
@@ -93,11 +93,11 @@ jobs:
       - run: echo Compiling ${{matrix.file}}
       - run: docker run --rm -v "${PWD}":/config esphome/esphome:dev compile ${{matrix.file}}
 
-
-#  final:
-#    name: Final ESPHome check
-#    runs-on: ubuntu-latest
-#    needs: [loop-stable, loop-beta, loop-dev]
-#    steps:
-#      - name: Getting your configuration from GitHub
-#        uses: actions/checkout@v2
+  # This is used by branch protections
+  final:
+    name: Final ESPHome check
+    runs-on: ubuntu-latest
+    needs: [loop-stable, loop-beta, loop-dev]
+    steps:
+      - name: Getting your configuration from GitHub
+        uses: actions/checkout@v2


### PR DESCRIPTION
As per https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks and https://github.com/community/community/discussions/13690