### PR TITLE
New phone

### DIFF
--- a/automation/aurora_alert.yaml
+++ b/automation/aurora_alert.yaml
@@ -15,7 +15,7 @@ action:
     data:
       title: "Aurora Alert"
       message: "Alert! The Aurora Borealis might be visible right now!"
-  - service: notify.mobile_app_nothing_phone_1
+  - service: notify.mobile_app_nothing_phone_2
     data:
       title: "Aurora Alert"
       message: "Alert! The Aurora Borealis might be visible right now!"

--- a/packages/givenergy.yaml
+++ b/packages/givenergy.yaml
@@ -98,7 +98,7 @@ automation:
       - service: switch.turn_on
         target:
           entity_id: switch.viewpoint_domestic_hot_water_0_boost
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Hot water boost triggered"
           message: "Hot water boost triggered whilst exporting."

--- a/packages/outside_lights.yaml
+++ b/packages/outside_lights.yaml
@@ -53,7 +53,7 @@ automation:
         entity_id: sun.sun
         state: "above_horizon"
     action:
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Motion outside!"
           message: >
@@ -130,7 +130,7 @@ automation:
       - service: homeassistant.turn_on
         entity_id:
           - group.outside_lights
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Motion outside!"
           message: >

--- a/packages/proximity_changes.yaml
+++ b/packages/proximity_changes.yaml
@@ -16,12 +16,12 @@ automation:
         entity_id: device_tracker.nothing_phone
         state: moving
     action:
-    - service: notify.mobile_app_nothing_phone_1
+    - service: notify.mobile_app_nothing_phone_2
       data:
         data:
           push:
             category: ARRIVING_HOME
         message: Kyle Approaching Home
-    - service: notify.mobile_app_nothing_phone_1
+    - service: notify.mobile_app_nothing_phone_2
       data:
         message: "Kyle approaching home"

--- a/packages/stove.yaml
+++ b/packages/stove.yaml
@@ -59,7 +59,7 @@ automation:
             type: announce
             # method: all
           message: "The stove requires more wood."
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "More wood needed!"
           message: >

--- a/packages/tin_hut.yaml
+++ b/packages/tin_hut.yaml
@@ -154,7 +154,7 @@ automation:
         data:
           title: "Tin Hut Doors Open"
           message: "The tin hut doors have been opened!"
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Tin Hut Doors Open"
           message: "The tin hut doors have been opened!"

--- a/packages/valetudo.yaml
+++ b/packages/valetudo.yaml
@@ -130,7 +130,7 @@ script:
       - service: script.tweet_engine
         data_template:
           tweet: "Dispatching my minion, Snowwhite the vacuum, to mop and clean the floor of the front hall!"
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Vacuuming"
           message: "Vacuuming of the front hall has started."
@@ -152,7 +152,7 @@ script:
       - service: script.tweet_engine
         data_template:
           tweet: "Dispatching my minion, Snowwhite the vacuum, to mop and clean the living room!"
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Vacuuming"
           message: "Vacuuming of the living room has started."
@@ -174,7 +174,7 @@ script:
       - service: script.tweet_engine
         data_template:
           tweet: "Dispatching my minion, Snowwhite the vacuum, to mop and clean the boot room floor!"
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Vacuuming"
           message: "Vacuuming of the boot room has started."
@@ -196,7 +196,7 @@ script:
       - service: script.tweet_engine
         data_template:
           tweet: "Dispatching my minion, Snowwhite the vacuum, to mop and clean the kitchen floor!"
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Vacuuming"
           message: "Vacuuming of the kitchen has started."
@@ -218,7 +218,7 @@ script:
       - service: script.tweet_engine
         data_template:
           tweet: "Dispatching my minion, Snowwhite the vacuum, to mop and clean the hallway!"
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Vacuuming"
           message: "Vacuuming of the hallway has started."
@@ -240,7 +240,7 @@ script:
       - service: script.tweet_engine
         data_template:
           tweet: "Dispatching my minion, Snowwhite the vacuum, to mop and clean the bathroom!"
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Vacuuming"
           message: "Vacuuming of the bathroom has started."
@@ -262,7 +262,7 @@ script:
       - service: script.tweet_engine
         data_template:
           tweet: "Dispatching my minion, Snowwhite the vacuum, to clean the study carpet!"
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Vacuuming"
           message: "Vacuuming of the study has started."
@@ -284,7 +284,7 @@ script:
       - service: script.tweet_engine
         data_template:
           tweet: "Dispatching my minion, Snowwhite the vacuum, to clean the craft room carpet!"
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Vacuuming"
           message: "Vacuuming of the craft room has started."
@@ -306,7 +306,7 @@ script:
       - service: script.tweet_engine
         data_template:
           tweet: "Dispatching my minion, Snowwhite the vacuum, to clean the guest room!"
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Vacuuming"
           message: "Vacuuming of the guest room has started."
@@ -328,7 +328,7 @@ script:
       - service: script.tweet_engine
         data_template:
           tweet: "Dispatching my minion, Snowwhite the vacuum, to clean the bedroom!"
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Vacuuming"
           message: "Vacuuming of the bedroom has started."
@@ -350,7 +350,7 @@ script:
       - service: script.tweet_engine
         data_template:
           tweet: "Dispatching my minion, Snowwhite the vacuum, to mop and clean the ensuite!"
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Vacuuming"
           message: "Vacuuming of the ensuite has started."

--- a/packages/valetudo_notifications.yaml
+++ b/packages/valetudo_notifications.yaml
@@ -41,7 +41,7 @@ automation:
       message: "{{ strings[msg_type] | default(strings['default_msg']) }}"
 
     action:
-      - service: notify.mobile_app_nothing_phone_1
+      - service: notify.mobile_app_nothing_phone_2
         data:
           title: Snowwhite vacuum
           message: "{{ message }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated notification target across multiple automations and scripts to route alerts to Nothing Phone 2 instead of Nothing Phone 1.
  * Affected areas: Aurora Alert, Boost hot water, Outside lights (motion and lights on), Proximity updates, Stove “More wood,” Tin Hut Doors Announce, Valetudo room-clean scripts (11 rooms), and Valetudo notifications.
  * No changes to triggers, conditions, messages, or other logic; only the destination device was updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->