### PR TITLE
Cancel the quick veto, not clear

### DIFF
--- a/packages/climate.yaml
+++ b/packages/climate.yaml
@@ -39,6 +39,7 @@ automation:
       - service: mypyllant.cancel_quick_veto
         target:
           entity_id: climate.viewpoint_zone_1_circuit_0_climate
+      - delay: "00:00:02"
       - service: climate.set_hvac_mode
         target:
           entity_id: climate.viewpoint_zone_1_circuit_0_climate

--- a/packages/climate.yaml
+++ b/packages/climate.yaml
@@ -36,7 +36,7 @@ automation:
       - trigger: template
         value_template: "{{ 'states.sensor.hwam_smart_stove_temperature' != 'unknown' }}"
     action:
-      - service: mypyllant.clear_quick_veto
+      - service: mypyllant.cancel_quick_veto
         target:
           entity_id: climate.viewpoint_zone_1_circuit_0_climate
       - service: climate.set_hvac_mode


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Turn on ASHP automation now reliably cancels any active Quick Veto override before setting HVAC mode and includes a brief delay to ensure the cancellation is applied, improving consistency when activating the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->