### PR TITLE
Unique IDs for groups

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -1,6 +1,7 @@
 ---
 default_view:
   name: Home
+  unique_id: default_view_group
   entities:
     - group.people_status
     - group.modes
@@ -15,6 +16,7 @@ default_view:
 
 environment_summary:
   name: Environment Summary
+  unique_id: environment_summary_group
   entities:
     - climate.rest_of_house_thermostat
     - climate.hot_water
@@ -22,6 +24,7 @@ environment_summary:
 
 kitchen:
   name: Kitchen
+  unique_id: kitchen_group
   entities:
     - sensor.kitchen_temperature
     - sensor.kitchen_esp8266_signal_level
@@ -32,6 +35,7 @@ kitchen:
 
 front_hall:
   name: Front Hall
+  unique_id: front_hall_group
   entities:
     - light.front_hall
     - sensor.front_hall_sensor_temperature
@@ -43,6 +47,7 @@ front_hall:
 
 living_room:
   name: Living Room
+  unique_id: living_room_group
   entities:
     - group.living_room_lights
     - media_player.living_room_kodi
@@ -55,6 +60,7 @@ living_room:
 
 living_room_lights:
   name: Living Room Lights
+  unique_id: living_room_lights_group
   entities:
     - light.living_room_1
     - light.living_room_2
@@ -65,6 +71,7 @@ living_room_lights:
 
 dining_nook_lights:
   name: Dining Nook
+  unique_id: dining_nook_lights_group
   entities:
     - light.dining_nook
     - light.dining_table_overhead
@@ -73,6 +80,7 @@ dining_nook_lights:
 
 bedroom_1:
   name: Master bedroom
+  unique_id: bedroom_1_group
   entities:
     - group.bedroom_1_lights
     - group.bedside_lights
@@ -89,6 +97,7 @@ bedroom_1:
 
 ensuite:
   name: Ensuite
+  unique_id: ensuite_group
   entities:
     - sensor.ensuite_lightlevel
     - binary_sensor.ensuite_motion_occupancy
@@ -100,17 +109,20 @@ ensuite:
     - light.ensuite_sink
 
 ensuite_facilities:
+  unique_id: ensuite_facilities_group
   entities:
     - light.ensuite_toilet
     - light.ensuite_sink
 
 bedroom_1_lights:
   name: Bedroom lights
+  unique_id: bedroom_1_lights_group
   entities:
     - light.master_bedroom
 
 bedroom_2:
   name: Guest bedroom
+  unique_id: bedroom_2_group
   entities:
     - light.guest_bedroom
     - sensor.guest_room_multi_sensor_temperature
@@ -119,6 +131,7 @@ bedroom_2:
 
 bedroom_3:
   name: Study
+  unique_id: bedroom_3_group
   entities:
     - media_player.study_ds
     - media_player.study
@@ -133,6 +146,7 @@ bedroom_3:
 
 bedroom_4:
   name: Craft room
+  unique_id: bedroom_4_group
   entities:
     - light.craft_room
     - light.craft_room_fairy_lights
@@ -143,29 +157,34 @@ bedroom_4:
 
 craft_room_lighting:
   name: Craft Room Lights
+  unique_id: craft_room_lighting_group
   entities:
     - light.craft_room
     - light.craft_room_fairy_lights
 
 study_lighting:
   name: Study Lights
+  unique_id: study_lighting_group
   entities:
     - light.study
     - light.monitor_lights
 
 hall:
   name: Hall lights
+  unique_id: hall_group
   entities:
     - light.hallway_bathroom
     - light.hallway_bedrooms
 
 bathroom:
   name: Bathroom
+  unique_id: bathroom_group
   entities:
     - light.master_bathroom
 
 hall_view:
   name: Hall
+  unique_id: hall_view_group
   entities:
     - light.hall
     - binary_sensor.hall_rooms_motion_occupancy
@@ -180,6 +199,7 @@ hall_view:
 
 outside:
   name: Outside
+  unique_id: outside_group
   entities:
     - sun.sun
     - binary_sensor.back_door_pir
@@ -197,6 +217,7 @@ outside:
 
 outside_lights:
   name: Outside Lights
+  unique_id: outside_lights_group
   entities:
     - light.front_floodlights
     - light.driveway_floodlights
@@ -210,6 +231,7 @@ outside_lights:
 
 climate:
   name: Climate
+  unique_id: climate_group
   entities:
     - climate.rest_of_house_thermostat
     - sensor.rest_of_house_average_temperature
@@ -223,6 +245,7 @@ climate:
 
 garage:
   name: Garage
+  unique_id: garage_group
   entities:
     - sensor.garage_lights_signal_level
     - light.garage_lights
@@ -233,6 +256,7 @@ garage:
 people:
   name: People
   icon: mdi:account-multiple
+  unique_id: people_group
   entities:
     - person.kyle
     - person.charlotte
@@ -243,12 +267,14 @@ people:
 ## Item groups ##
 bedside_lights:
   name: Bedside Lights
+  unique_id: bedside_lights_group
   entities:
     - light.bedside_kyle
     - light.bedside_charlotte
 
 lightswitch_relays:
   name: Lightswitch Relays
+  unique_id: lightswitch_relays_group
   entities:
     - switch.master_bedroom_lightswitch_relay
     - switch.guest_bedroom_lightswitch_relay
@@ -258,18 +284,21 @@ lightswitch_relays:
 
 people_status:
   name: People Status
+  unique_id: people_status_group
   entities:
     - sensor.kyle_status
     - sensor.charlotte_status
 
 test:
   name: Test
+  unique_id: test_group
   entities:
     - switch.tellybox
     - media_player.living_room_panasonic_tv
 
 other:
   name: Other
+  unique_id: other_group
   entities:
     - group.lightswitch_relays
     - switch.energenie_1

--- a/packages/christmas_lights.yaml
+++ b/packages/christmas_lights.yaml
@@ -2,6 +2,7 @@
 group:
   christmas_lights:
     name: Christmas Lights
+    unique_id: christmas_lights_group
     entities:
       - switch.energenie_1
       - switch.energenie_2

--- a/packages/room_aware.yaml
+++ b/packages/room_aware.yaml
@@ -2,6 +2,7 @@
 group:
   echos:
     name: All Echos
+    unique_id: echos_group
     entities:
       - media_player.bedroom
       - media_player.kitchen

--- a/packages/snmp_bandwidth.yaml
+++ b/packages/snmp_bandwidth.yaml
@@ -98,6 +98,7 @@ automation:
 group:
   snmp_monitor:
     name: Bandwith Monitoring
+    unique_id: snmp_monitor_group
     entities:
       - sensor.internet_speed_in
       - sensor.internet_speed_out
@@ -105,6 +106,7 @@ group:
       - sensor.wan_traffic_out_mean
   snmp_raw_values:
     name: SNMP Raw Values
+    unique_id: snmp_raw_values_group
     entities:
       - sensor.snmp_wan_in
       - sensor.snmp_wan_out

--- a/packages/valetudo.yaml
+++ b/packages/valetudo.yaml
@@ -75,6 +75,7 @@ input_boolean:
 group:
   vacuum_rooms:
     name: Vacuum Rooms
+    unique_id: vacuum_rooms_group
     entities:
       - input_boolean.vacuum_bootroom
       - input_boolean.vacuum_fronthall


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Assigned stable, consistent identifiers to most device groups (rooms, lights, outside, climate, people, SNMP monitoring, voice assistants, vacuum rooms, Christmas lights) to improve reliability across automations, dashboards, and imports/exports.
  * Refreshed a few group memberships to better reflect current devices.
  * No changes to UI or day-to-day behavior; updates are backward-compatible and focused on configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->