### PR TITLE
Fix media dimming

### DIFF
--- a/packages/living_room_tv_dim.yaml
+++ b/packages/living_room_tv_dim.yaml
@@ -15,12 +15,12 @@ automation:
       - condition: or
         conditions:
           - condition: state
-            entity_id: light.living_room_ceiling
+            entity_id: light.living_room
             state: 'on'
     action:
       - service: light.turn_off
         entity_id:
-          - light.living_room_ceiling
+          - light.living_room
       - service: light.turn_on
         entity_id:
           - light.cosy_lights


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Living room dimmer now uses a single ceiling light for sensing/control.
  * Presence detection improved for the dining nook (Zone 2).
  * Sideboard light removed from dining nook final lights; cosy lights now turn on after the living room light is turned off; art and train cabinet lights retained.

* **Refactor**
  * Automation logic consolidated for simpler, more consistent device handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->