### PR TITLE
Rename all the things

### DIFF
--- a/esphome/craftroom_switch.yaml
+++ b/esphome/craftroom_switch.yaml
@@ -1,9 +1,9 @@
 ---
 substitutions:
-  name: "craftroom_switch"
-  device_name: craftroom_switch
+  name: "craftroom_lightswitch"
+  device_name: craftroom_lightswitch
   device_description: Craft Room Lightswitch
-  friendly_name: Craft Room Switch
+  friendly_name: Craft Room Lightswitch
   default_state: "RESTORE_DEFAULT_ON"
   device_format: EU
   gang_count: 1

--- a/esphome/ensuite_switch.yaml
+++ b/esphome/ensuite_switch.yaml
@@ -1,9 +1,9 @@
 ---
 substitutions:
-  name: "ensuite_switch"
-  device_name: ensuite_switch
+  name: "ensuite_lightswitch"
+  device_name: ensuite_lightswitch
   device_description: Ensuite Lightswitch
-  friendly_name: Ensuite Switch
+  friendly_name: Ensuite Lightswitch
   default_state: "RESTORE_DEFAULT_ON"
   device_format: EU
   gang_count: 1

--- a/esphome/front_hall_dual_switch.yaml
+++ b/esphome/front_hall_dual_switch.yaml
@@ -1,8 +1,8 @@
 ---
 substitutions:
-  name: "front_hall_dual_switch"
-  friendly_name: "Front Hall Dual Switch"
-  device_description: "Front Hall Dual Light Switch"
+  name: "front_hall_dual_lightswitch"
+  friendly_name: "Front Hall Dual Lightswitch"
+  device_description: "Front Hall Dual Lightswitch"
   default_state: "RESTORE_DEFAULT_ON"
   device_format: EU
   gang_count: 2

--- a/esphome/guestbedroom_switch.yaml
+++ b/esphome/guestbedroom_switch.yaml
@@ -1,9 +1,9 @@
 ---
 substitutions:
-  name: "guestbedroom_switch"
-  device_name: guestbedroom_switch
+  name: "guestbedroom_lightswitch"
+  device_name: guestbedroom_lightswitch
   device_description: Guest Bedroom Lightswitch
-  friendly_name: Guest Bedroom Switch
+  friendly_name: Guest Bedroom Lightswitch
   default_state: "RESTORE_DEFAULT_ON"
   device_format: EU
   gang_count: 1

--- a/esphome/hall_dual_switch.yaml
+++ b/esphome/hall_dual_switch.yaml
@@ -1,8 +1,8 @@
 ---
 substitutions:
-  name: "hall_dual_switch"
-  friendly_name: "Hall Dual Switch"
-  device_description: "Hall Dual Light Switch"
+  name: "hall_dual_lightswitch"
+  friendly_name: "Hall Dual Lightswitch"
+  device_description: "Hall Dual Lightswitch"
   default_state: "RESTORE_DEFAULT_ON"
   device_format: EU
   gang_count: 2

--- a/esphome/hall_single_switch.yaml
+++ b/esphome/hall_single_switch.yaml
@@ -1,8 +1,8 @@
 ---
 substitutions:
-  name: "hall_single_switch"
-  friendly_name: "Hall Single Switch"
-  device_description: "Hall Single Light Switch"
+  name: "hall_single_lightswitch"
+  friendly_name: "Hall Single Lightswitch"
+  device_description: "Hall Single Lightswitch"
   device_format: EU
   gang_count: 1
 

--- a/esphome/kitchen_switch.yaml
+++ b/esphome/kitchen_switch.yaml
@@ -1,8 +1,8 @@
 ---
 substitutions:
-  name: "kitchen_switch"
-  friendly_name: "Kitchen Switch"
-  device_description: "Kitchen Light Switch"
+  name: "kitchen_lightswitch"
+  friendly_name: "Kitchen Lightswitch"
+  device_description: "Kitchen Lightswitch"
   device_format: EU
   gang_count: 2
 

--- a/esphome/living_room_switch.yaml
+++ b/esphome/living_room_switch.yaml
@@ -1,8 +1,8 @@
 ---
 substitutions:
-  name: "living_room_switch"
-  friendly_name: "Living Room Switch"
-  device_description: "Living Room Light Switch"
+  name: "living_room_lightswitch"
+  friendly_name: "Living Room Lightswitch"
+  device_description: "Living Room Lightswitch"
   device_format: EU
   gang_count: 3
 

--- a/esphome/masterbedroom_switch.yaml
+++ b/esphome/masterbedroom_switch.yaml
@@ -1,8 +1,8 @@
 ---
 substitutions:
-  name: "masterbedroom_switch"
+  name: "masterbedroom_lightswitch"
   friendly_name: "Master Bedroom Lightswitch"
-  device_description: "Master Bedroom Light Switch"
+  device_description: "Master Bedroom Lightswitch"
   device_format: EU
   gang_count: 1
 

--- a/esphome/study_switch.yaml
+++ b/esphome/study_switch.yaml
@@ -1,8 +1,8 @@
 ---
 substitutions:
-  name: "study_switch"
-  friendly_name: "Study Switch"
-  device_description: "Study Light Switch"
+  name: "study_lightswitch"
+  friendly_name: "Study Lightswitch"
+  device_description: "Study Lightswitch"
   device_format: EU
   gang_count: 1
 

--- a/packages/craft_room.yaml
+++ b/packages/craft_room.yaml
@@ -14,15 +14,15 @@ automation:
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: craftroom_switch
+          device_name: craftroom_lightswitch
           action: click
     action:
       - service: light.turn_on
         data:
-          entity_id: light.craftroom_switch_lights_all
+          entity_id: light.craftroom_lightswitch_lights_all
           effect: "Rainbow - Fast"
       - service: switch.turn_on
-        entity_id: switch.craft_room_switch_relay_1
+        entity_id: switch.craftroom_lightswitch_relay_1
       - service: light.toggle
         entity_id: light.craft_room_lighting
       - service: logbook.log
@@ -32,7 +32,7 @@ automation:
       - delay: "00:00:05"
       - service: light.turn_off
         target:
-          entity_id: light.craftroom_switch_lights_all
+          entity_id: light.craftroom_lightswitch_lights_all
         data:
           transition: 1
 
@@ -44,12 +44,12 @@ automation:
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: craftroom_switch
+          device_name: craftroom_lightswitch
           action: double_click
     action:
       - service: light.turn_on
         data:
-          entity_id: light.craft_room_switch_lights_all
+          entity_id: light.craftroom_lightswitch_lights_all
           effect: "Rainbow - Fast"
       - service: light.toggle
         entity_id: light.craft_room_fairy_lights
@@ -60,6 +60,6 @@ automation:
       - delay: "00:00:05"
       - service: light.turn_off
         target:
-          entity_id: light.craft_room_switch_lights_all
+          entity_id: light.craftroom_lightswitch_lights_all
         data:
           transition: 1

--- a/packages/ensuite.yaml
+++ b/packages/ensuite.yaml
@@ -21,16 +21,16 @@ automation:
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: ensuite_switch
+          device_name: ensuite_lightswitch
           action: click
     action:
       - service: light.turn_on
         data:
-          entity_id: light.ensuite_switch_lights_all
+          entity_id: light.ensuite_lightswitch_lights_all
           effect: "Rainbow - Fast"
       - service: switch.turn_on
         entity_id:
-          - switch.ensuite_switch_relay_1
+          - switch.ensuite_lightswitch_relay_1
       - service: light.toggle
         data:
           entity_id: >
@@ -48,7 +48,7 @@ automation:
       - delay: "00:00:05"
       - service: light.turn_off
         target:
-          entity_id: light.ensuite_switch_lights_all
+          entity_id: light.ensuite_lightswitch_lights_all
         data:
           transition: 1
 

--- a/packages/guest_bedroom.yaml
+++ b/packages/guest_bedroom.yaml
@@ -9,15 +9,15 @@ automation:
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: guestbedroom_switch
+          device_name: guestbedroom_lightswitch
           action: click
     action:
       - service: light.turn_on
         data:
-          entity_id: light.guest_bedroom_switch_lights_all
+          entity_id: light.guestbedroom_lightswitch_lights_all
           effect: "Rainbow - Fast"
       - service: switch.turn_on
-        entity_id: switch.guest_bedroom_switch_relay_1
+        entity_id: switch.guestbedroom_lightswitch_relay_1
       - service: light.toggle
         entity_id: light.guest_bedroom
       - service: logbook.log
@@ -27,6 +27,6 @@ automation:
       - delay: "00:00:05"
       - service: light.turn_off
         target:
-          entity_id: light.guest_bedroom_switch_lights_all
+          entity_id: light.guestbedroom_lightswitch_lights_all
         data:
           transition: 1

--- a/packages/hallway.yaml
+++ b/packages/hallway.yaml
@@ -17,12 +17,12 @@ automation:
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: hall_single_switch
+          device_name: hall_single_lightswitch
           action: click
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: hall_dual_switch
+          device_name: hall_dual_lightswitch
           action: click
           button_id: "2"
     action:
@@ -31,15 +31,15 @@ automation:
       - service: light.turn_on
         target:
           entity_id:
-            - light.hall_single_switch_lights_all
-            - light.hall_dual_switch_lights_all
+            - light.hall_single_lightswitch_lights_all
+            - light.hall_dual_lightswitch_lights_all
         data:
           effect: "Rainbow - Fast"
       - service: switch.turn_on
         target:
           entity_id:
-            - switch.hall_single_switch_relay_1
-            - switch.hall_dual_switch_relay_1
+            - switch.hall_single_lightswitch_relay_1
+            - switch.hall_dual_lightswitch_relay_1
       - service: light.toggle
         target:
           entity_id:
@@ -52,8 +52,8 @@ automation:
       - service: light.turn_off
         target:
           entity_id:
-            - light.hall_single_switch_lights_all
-            - light.hall_dual_switch_lights_all
+            - light.hall_single_lightswitch_lights_all
+            - light.hall_dual_lightswitch_lights_all
         data:
           transition: 1
 

--- a/packages/kitchen.yaml
+++ b/packages/kitchen.yaml
@@ -27,16 +27,16 @@ automation:
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: kitchen_switch
+          device_name: kitchen_lightswitch
           action: click
           button_id: "1"
     action:
       - service: light.turn_on
         data:
-          entity_id: light.kitchen_switch_lights_all
+          entity_id: light.kitchen_lightswitch_lights_all
           effect: "Rainbow - Fast"
       - service: switch.turn_on
-        entity_id: switch.kitchen_switch_relay_1
+        entity_id: switch.kitchen_lightswitch_relay_1
       - service: light.toggle
         entity_id: light.kitchen_ceiling_lights
       - service: logbook.log
@@ -46,7 +46,7 @@ automation:
       - delay: "00:00:05"
       - service: light.turn_off
         target:
-          entity_id: light.kitchen_switch_lights_all
+          entity_id: light.kitchen_lightswitch_lights_all
         data:
           transition: 1
 
@@ -58,16 +58,16 @@ automation:
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: kitchen_switch
+          device_name: kitchen_lightswitch
           action: click
           button_id: "2"
     action:
       - service: light.turn_on
         data:
-          entity_id: light.kitchen_switch_lights_all
+          entity_id: light.kitchen_lightswitch_lights_all
           effect: "Rainbow - Fast"
       - service: switch.turn_on
-        entity_id: switch.kitchen_switch_relay_2
+        entity_id: switch.kitchen_lightswitch_relay_2
       - service: light.toggle
         entity_id: light.kitchen_worktop_lights
       - service: logbook.log
@@ -77,7 +77,7 @@ automation:
       - delay: "00:00:05"
       - service: light.turn_off
         target:
-          entity_id: light.kitchen_switch_lights_all
+          entity_id: light.kitchen_lightswitch_lights_all
         data:
           transition: 1
 

--- a/packages/living_room_lights.yaml
+++ b/packages/living_room_lights.yaml
@@ -36,17 +36,17 @@ automation:
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: living_room_switch
+          device_name: living_room_lightswitch
           action: click
           button_id: "3"
     action:
       - service: light.turn_on
         data:
-          entity_id: light.living_room_switch_lights_all
+          entity_id: light.living_room_lightswitch_lights_all
           effect: "Rainbow - Fast"
       - service: switch.turn_on
         entity_id:
-          - switch.living_room_switch_relay_1
+          - switch.living_room_lightswitch_relay_1
       - service: light.toggle
         data:
           entity_id:
@@ -58,7 +58,7 @@ automation:
       - delay: "00:00:05"
       - service: light.turn_off
         target:
-          entity_id: light.living_room_switch_lights_all
+          entity_id: light.living_room_lightswitch_lights_all
         data:
           transition: "1"
 
@@ -70,17 +70,17 @@ automation:
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: living_room_switch
+          device_name: living_room_lightswitch
           action: click
           button_id: "2"
     action:
       - service: light.turn_on
         data:
-          entity_id: light.living_room_switch_lights_all
+          entity_id: light.living_room_lightswitch_lights_all
           effect: "Rainbow - Fast"
       - service: switch.turn_on
         entity_id:
-          - switch.living_room_switch_relay_2
+          - switch.living_room_lightswitch_relay_2
       - service: light.toggle
         data:
           entity_id:
@@ -92,7 +92,7 @@ automation:
       - delay: "00:00:05"
       - service: light.turn_off
         target:
-          entity_id: light.living_room_switch_lights_all
+          entity_id: light.living_room_lightswitch_lights_all
         data:
           transition: 1
 
@@ -104,17 +104,17 @@ automation:
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: living_room_switch
+          device_name: living_room_lightswitch
           action: click
           button_id: "1"
     action:
       - service: light.turn_on
         data:
-          entity_id: light.living_room_switch_lights_all
+          entity_id: light.living_room_lightswitch_lights_all
           effect: "Rainbow - Fast"
       - service: switch.turn_on
         entity_id:
-          - switch.living_room_switch_relay_3
+          - switch.living_room_lightswitch_relay_3
       - service: light.toggle
         data:
           entity_id:
@@ -126,7 +126,7 @@ automation:
       - delay: "00:00:05"
       - service: light.turn_off
         target:
-          entity_id: light.living_room_switch_lights_all
+          entity_id: light.living_room_lightswitch_lights_all
         data:
           transition: 1
 

--- a/packages/master_bathroom.yaml
+++ b/packages/master_bathroom.yaml
@@ -29,17 +29,17 @@ automation:
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: hall_dual_switch
+          device_name: hall_dual_lightswitch
           action: click
           button_id: "1"
     action:
       - service: light.turn_on
         data:
-          entity_id: light.hall_dual_switch_lights_all
+          entity_id: light.hall_dual_lightswitch_lights_all
           effect: "Rainbow - Fast"
       - service: switch.turn_on
         entity_id:
-          - switch.hall_dual_switch_relay_2
+          - switch.hall_dual_lightswitch_relay_2
       - service: light.toggle
         data:
           entity_id: light.master_bathroom
@@ -50,6 +50,6 @@ automation:
       - delay: "00:00:05"
       - service: light.turn_off
         target:
-          entity_id: light.hall_dual_switch_lights_all
+          entity_id: light.hall_dual_lightswitch_lights_all
         data:
           transition: 1

--- a/packages/master_bedroom_lights.yaml
+++ b/packages/master_bedroom_lights.yaml
@@ -7,15 +7,15 @@ automation:
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: masterbedroom_switch
+          device_name: masterbedroom_lightswitch
           action: click
     action:
       - service: light.turn_on
         data:
-          entity_id: light.master_bedroom_switch_lights_all
+          entity_id: light.masterbedroom_lightswitch_lights_all
           effect: "Rainbow - Fast"
       - service: switch.turn_on
-        entity_id: switch.masterbedroom_switch_relay_1
+        entity_id: switch.masterbedroom_lightswitch_relay_1
       - service: light.toggle
         entity_id: light.master_bedroom
       - service: logbook.log
@@ -25,7 +25,7 @@ automation:
       - delay: "00:00:05"
       - service: light.turn_off
         target:
-          entity_id: light.master_bedroom_switch_lights_all
+          entity_id: light.masterbedroom_lightswitch_lights_all
         data:
           transition: 1
 
@@ -35,7 +35,7 @@ automation:
       - platform: event
         event_type: esphome.button_pressed
         event_data:
-          device_name: masterbedroom_switch
+          device_name: masterbedroom_lightswitch
           click_type: double
     action:
       - service: switch.turn_on
@@ -70,7 +70,7 @@ automation:
       - platform: event
         event_type: esphome.button_pressed
         event_data:
-          device_name: masterbedroom_switch
+          device_name: masterbedroom_lightswitch
           click_type: triple
     action:
       - service: light.toggle

--- a/packages/study_lights.yaml
+++ b/packages/study_lights.yaml
@@ -8,15 +8,15 @@ automation:
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: study_switch
+          device_name: study_lightswitch
           action: click
     action:
       - service: light.turn_on
         data:
-          entity_id: light.study_switch_lights_all
+          entity_id: light.study_lightswitch_lights_all
           effect: "Rainbow - Fast"
       - service: switch.turn_on
-        entity_id: switch.study_switch_relay_1
+        entity_id: switch.study_lightswitch_relay_1
       - service: light.toggle
         entity_id:
           - light.study_lights
@@ -28,7 +28,7 @@ automation:
       - delay: "00:00:05"
       - service: light.turn_off
         target:
-          entity_id: light.study_switch_lights_all
+          entity_id: light.study_lightswitch_lights_all
         data:
           transition: 1
 
@@ -40,12 +40,12 @@ automation:
       - platform: event
         event_type: esphome.tx_ultimate_easy
         event_data:
-          device_name: study_switch
+          device_name: study_lightswitch
           action: double_click
     action:
       - service: light.turn_on
         data:
-          entity_id: light.study_switch_lights_all
+          entity_id: light.study_lightswitch_lights_all
           effect: "Rainbow - Fast"
       - service: light.toggle
         entity_id:
@@ -58,7 +58,7 @@ automation:
       - delay: "00:00:05"
       - service: light.turn_off
         target:
-          entity_id: light.study_switch_lights_all
+          entity_id: light.study_lightswitch_lights_all
         data:
           transition: 1
 

--- a/scripts/ikea_reset.yaml
+++ b/scripts/ikea_reset.yaml
@@ -4,7 +4,7 @@ reset_ikea:
   sequence:
     - service: switch.turn_off
       target:
-        entity_id: switch.hall_single_switch_relay_1
+        entity_id: switch.hall_single_lightswitch_relay_1
     - delay:
         hours: 0
         minutes: 0
@@ -15,7 +15,7 @@ reset_ikea:
         sequence:
           - service: switch.turn_on
             target:
-              entity_id: switch.hall_single_switch_relay_1
+              entity_id: switch.hall_single_lightswitch_relay_1
           - delay:
               hours: 0
               minutes: 0
@@ -23,7 +23,7 @@ reset_ikea:
               milliseconds: 400
           - service: switch.turn_off
             target:
-              entity_id: switch.hall_single_switch_relay_1
+              entity_id: switch.hall_single_lightswitch_relay_1
           - delay:
               hours: 0
               minutes: 0
@@ -31,5 +31,5 @@ reset_ikea:
               milliseconds: 500
     - service: switch.turn_on
       target:
-        entity_id: switch.hall_single_switch_relay_1
+        entity_id: switch.hall_single_lightswitch_relay_1
   mode: single

--- a/switches.yaml
+++ b/switches.yaml
@@ -11,8 +11,18 @@
   name: Lightswitch Relays
   unique_id: lightswitch_relays
   entities:
-    - switch.master_bedroom_lightswitch_relay
-    - switch.guest_bedroom_lightswitch_relay
-    - switch.study_lightswitch_relay
-    - switch.craft_room_lightswitch_relay
-    - switch.ensuite_lightswitch_relay
+    - switch.masterbedroom_lightswitch_relay_1
+    - switch.guestbedroom_lightswitch_relay_1
+    - switch.study_lightswitch_relay_1
+    - switch.craftroom_lightswitch_relay_1
+    - switch.ensuite_lightswitch_relay_1
+    - switch.kitchen_lightswitch_relay_1
+    - switch.kitchen_lightswitch_relay_2
+    - switch.living_room_lightswitch_relay_1
+    - switch.living_room_lightswitch_relay_2
+    - switch.living_room_lightswitch_relay_3
+    - switch.hall_single_lightswitch_relay_1
+    - switch.hall_dual_lightswitch_relay_1
+    - switch.hall_dual_lightswitch_relay_2
+    - switch.front_hall_dual_lightswitch_relay_1
+    - switch.front_hall_dual_lightswitch_relay_2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed device identifiers across ESPHome and Home Assistant configurations from "switch" to "lightswitch" naming convention for improved clarity and consistency across 15+ rooms and automation packages.
  * Updated corresponding automation entity references and switch group definitions to reflect the new naming scheme.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->