### PR TITLE
Fix ensuite motion light failure from broken time_of_day

### DIFF
--- a/automation/home_late_dark.yaml
+++ b/automation/home_late_dark.yaml
@@ -32,6 +32,8 @@ action:
         100
         {% elif states('sensor.time_of_day') == "Night" %}
         30
+        {% else %}
+        30
         {% endif %}
       transition: >
         {% if states('sensor.time_of_day') == "Morning" %}
@@ -40,6 +42,8 @@ action:
         {{ 2.0 }}
         {% elif states('sensor.time_of_day') == "Night" %}
         {{ 5.0 }}
+        {% else %}
+        {{ 5.0 }}
         {% endif %}
       color_temp_kelvin: >
         {% if states('sensor.time_of_day') == "Morning" %}
@@ -47,6 +51,8 @@ action:
         {% elif states('sensor.time_of_day') == "Day" %}
         3333
         {% elif states('sensor.time_of_day') == "Night" %}
+        2667
+        {% else %}
         2667
         {% endif %}
   - service: light.turn_on

--- a/packages/ensuite.yaml
+++ b/packages/ensuite.yaml
@@ -76,6 +76,8 @@ automation:
             {{ 2.0 }}
             {% elif states('sensor.time_of_day') == "Night" %}
             {{ 30.0 }}
+            {% else %}
+            {{ 2.0 }}
             {% endif %}
 
   # - alias: Ensuite shower activity

--- a/sensors.yaml
+++ b/sensors.yaml
@@ -66,18 +66,6 @@
 
 - platform: template
   sensors:
-    time_of_day:
-      unique_id: time_of_day
-      value_template: >
-        {% set current_hour = strptime(states('sensor.time'), "%H:%M").hour %}
-        {% if 6 <= current_hour < 9 %}
-          Morning
-        {% elif 9 <= current_hour < 22 %}
-          Day
-        {% else %}
-          Night
-        {% endif %}
-
     forecast_2_hours:
       value_template: >-
         {% set f = state_attr('weather.pirateweather', 'forecast') %}

--- a/template.yaml
+++ b/template.yaml
@@ -1,6 +1,19 @@
 ---
 - trigger:
     - platform: time_pattern
+      minutes: "/1"
+    - platform: homeassistant
+      event: start
+  sensor:
+    - name: Time of Day
+      unique_id: time_of_day
+      state: >
+        {% set h = now().hour %}
+        {% if 6 <= h < 9 %}Morning
+        {% elif 9 <= h < 22 %}Day
+        {% else %}Night{% endif %}
+- trigger:
+    - platform: time_pattern
       minutes: "/30"
   action:
     - service: weather.get_forecasts


### PR DESCRIPTION
## Problem

The **Ensuite motion** automation fails at runtime with:

```
Error: expected float for dictionary value @ data['transition']
service_data: { entity_id: light.ensuite, transition: '' }
```

The failure (logged at 00:44, which should map to "Night" → `30.0`) proves two compounding problems.

## Root cause

`sensor.time_of_day` was a legacy `platform: template` sensor that derived its value from `sensor.time` (the `time_date` platform) via `strptime(states('sensor.time'), "%H:%M")`. When `sensor.time` is `unknown`/`unavailable`, `strptime` errors and `time_of_day` becomes `unknown` — i.e. "no longer provided by the template integration".

The downstream `transition` template only handled `Morning`/`Day`/`Night` with no `{% else %}` clause, so an unexpected `time_of_day` state rendered to an empty string `''`, failing HA's float validation.

## Changes

**Modernize & harden `sensor.time_of_day`:**
- `sensors.yaml` — removed the fragile legacy `platform: template` block.
- `template.yaml` — re-added as a modern trigger-based `template:` sensor driven off `now().hour` directly (no dependency on `sensor.time`), refreshed every minute and on HA start. Same `unique_id: time_of_day` (entity_id preserved) and same Morning/Day/Night boundaries, so all downstream consumers are unaffected.

**Defensive `{% else %}` defaults** (so a bad upstream state can never again render an invalid value):
- `packages/ensuite.yaml` — motion `transition` → `{% else %} 2.0`.
- `automation/home_late_dark.yaml` — `brightness_pct` → `30`, `transition` → `5.0`, `color_temp_kelvin` → `2667`.

## Verification

- YAML parsing of all four files passes.
- Full `ha core check` / template + automation reload should be run on the HA host (no runtime available in this checkout).
- After reload, confirm `sensor.time_of_day` is no longer `unavailable`, then trigger `binary_sensor.ensuite_motion_occupancy` and confirm the light turns on with a valid float `transition` and no error in the trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganised and consolidated time-of-day sensor configuration for improved system architecture and reliability.
  * Enhanced home lighting automation rules by implementing explicit fallback behaviours and default values, ensuring consistent adjustments to brightness levels, colour temperature settings, and transition timings are reliably applied throughout all hours of the day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->