### PR TITLE
Fix invalid entity_id template in Living Room motion automation

### DIFF
--- a/packages/living_room_lights.yaml
+++ b/packages/living_room_lights.yaml
@@ -294,12 +294,7 @@ automation:
     action:
       - service: light.turn_on
         data:
-          entity_id: >
-            {% if states('sensor.time_of_day') == "Morning" %}
-              - light.living_room
-              - light.dining_nook
-            {% else %}
-              - light.cosy_lights
-              - light.art
-              - light.train_cabinets
-            {% endif %}
+          entity_id: >-
+            {{ ['light.living_room', 'light.dining_nook']
+               if states('sensor.time_of_day') == 'Morning'
+               else ['light.cosy_lights', 'light.art', 'light.train_cabinets'] }}


### PR DESCRIPTION
## Summary
- The "Living Room motion" automation's `light.turn_on` action built `entity_id` from a Jinja block that rendered YAML-list-looking text (literal `- ` bullets). Once templated this is just a plain multi-line string, not a valid entity ID list, causing the automation trace error `not a valid value for dictionary value @ data['entity_id']`.
- Replaced it with a single-line Jinja expression that evaluates to a native list, which Home Assistant parses correctly.

## Test plan
- [x] `yamllint -c .github/yamllint-config.yml packages/living_room_lights.yaml`
- [x] `check_config` against `homeassistant/home-assistant:stable` — no new errors introduced (remaining warnings are pre-existing missing custom components, unrelated to this file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the Living Room motion lighting automation, making the light selection logic more compact and easier to maintain.
  * No user-facing behaviour changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->