### PR TITLE
Fix Owntracks Refresh: mqtt.publish payload_template key removed

### DIFF
--- a/scripts/refresh_devices.yaml
+++ b/scripts/refresh_devices.yaml
@@ -3,8 +3,8 @@ refresh_devices:
   - service: mqtt.publish
     data:
       topic: "owntracks/bagpuss/a0001/cmd"
-      payload_template: '{"_type":"cmd","action":"reportLocation"}'
+      payload: '{"_type":"cmd","action":"reportLocation"}'
   - service: mqtt.publish
     data:
       topic: "owntracks/charlotte/thea/cmd"
-      payload_template: '{"_type":"cmd","action":"reportLocation"}'
+      payload: '{"_type":"cmd","action":"reportLocation"}'


### PR DESCRIPTION
## Summary
- `mqtt.publish` no longer supports the `payload_template` field (removed from the schema; `payload` itself now supports templates).
- This made `automation.owntracks_refresh` fail every 15 minutes with `Invalid data for call_service at pos 1: extra keys not allowed @ data['payload_template']`, per home-assistant.log.
- Fix: rename `payload_template` -> `payload` in `scripts/refresh_devices.yaml` (used by this automation).

## Test plan
- [x] `yamllint -c .github/yamllint-config.yml scripts/refresh_devices.yaml`
- [x] `check_config` against `homeassistant/home-assistant:stable` in Docker — no new errors vs. baseline
- [ ] Confirm on next scheduled run that `automation.owntracks_refresh` no longer logs an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how location report commands are sent to connected devices, making device refresh actions more reliable.
  * Added a missing command payload entry to ensure all targeted devices receive the expected request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->