### PR TITLE
Fix Monitor Traffic In/Out: clamp negative delta from counter reset

### DIFF
--- a/packages/snmp_bandwidth.yaml
+++ b/packages/snmp_bandwidth.yaml
@@ -82,7 +82,10 @@ automation:
       - service: input_number.set_value
         data:
           entity_id: input_number.internet_traffic_delta_in
-          value: '{{ ((trigger.to_state.state | int - trigger.from_state.state | int) * 8 ) / ( as_timestamp(trigger.to_state.last_updated) - as_timestamp(trigger.from_state.last_updated) ) }}'
+          # The SNMP counter resets/wraps on device reboot, which can make
+          # to_state < from_state and produce a negative delta. Clamp at 0
+          # rather than erroring against the input_number's min.
+          value: '{{ [ ((trigger.to_state.state | int - trigger.from_state.state | int) * 8 ) / ( as_timestamp(trigger.to_state.last_updated) - as_timestamp(trigger.from_state.last_updated) ), 0 ] | max }}'
 
   - id: snmp_monitor_traffic_out
     alias: Monitor Traffic Out
@@ -93,7 +96,9 @@ automation:
       - service: input_number.set_value
         data:
           entity_id: input_number.internet_traffic_delta_out
-          value: '{{ ((trigger.to_state.state | int - trigger.from_state.state | int) * 8 ) / ( as_timestamp(trigger.to_state.last_updated) - as_timestamp(trigger.from_state.last_updated) ) }}'
+          # See snmp_monitor_traffic_in: clamp negative deltas from counter
+          # resets/wraps instead of erroring against the input_number's min.
+          value: '{{ [ ((trigger.to_state.state | int - trigger.from_state.state | int) * 8 ) / ( as_timestamp(trigger.to_state.last_updated) - as_timestamp(trigger.from_state.last_updated) ), 0 ] | max }}'
 
 group:
   snmp_monitor:


### PR DESCRIPTION
## Summary
- `automation.monitor_traffic_in` / `automation.monitor_traffic_out` compute a bandwidth delta from the raw SNMP WAN counters.
- When the router/counter resets (e.g. reboot), `to_state < from_state`, producing a large negative delta that violates `input_number.internet_traffic_delta_{in,out}`'s `min: 0`, per home-assistant.log (`Invalid value for input_number... range 0.0 - 1000000000000.0`).
- Fix: clamp the computed value at 0 with a `[value, 0] | max` template filter.

## Test plan
- [x] `yamllint -c .github/yamllint-config.yml packages/snmp_bandwidth.yaml`
- [x] `check_config` against `homeassistant/home-assistant:stable` in Docker — no new errors vs. baseline
- [ ] Confirm no further "Invalid value for input_number.internet_traffic_delta_*" errors after a counter reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)