### PR TITLE
Fix Bandwidthometer Value: handle sensor being unavailable

### DIFF
--- a/packages/bandwidthometer.yaml
+++ b/packages/bandwidthometer.yaml
@@ -21,7 +21,7 @@ automation:
         # brightness_pct: {{ (states('input_number.bandwidth_in_as_a_percentage') | float) | round(0) | int }}
         # brightness_pct: sensor.bandwidth_in_as_percentage
         brightness_pct: >
-          {{ states.sensor.bandwidth_in_as_percentage.state|int}}
+          {{ states('sensor.bandwidth_in_as_percentage') | int(0) }}
 
   - id: scale_backlight_up
     alias: Bandwidthometer Backlight On


### PR DESCRIPTION
## Summary
- `automation.bandwidthometer_value`'s brightness template used `.state|int` with no default, which raised when `sensor.bandwidth_in_as_percentage` was `unavailable`, per home-assistant.log (`ValueError: Template error: int got invalid input 'unavailable' ... but no default was specified`).
- Fix: use `states('sensor.bandwidth_in_as_percentage') | int(0)`, which is null/unavailable-safe.

## Test plan
- [x] `yamllint -c .github/yamllint-config.yml packages/bandwidthometer.yaml`
- [x] `check_config` against `homeassistant/home-assistant:stable` in Docker — no new errors vs. baseline
- [ ] Confirm no further template errors when the source sensor is briefly `unavailable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)