### PR TITLE
Fix flight/device-alert notify failures: smtp init + resilience

### DIFF
--- a/notify.yaml
+++ b/notify.yaml
@@ -3,7 +3,7 @@
   name: email_kyle
   server: smtp.gmail.com
   port: 587
-  starttls: true
+  encryption: starttls
   username: !secret gmail_username
   password: !secret gmail_password
   sender: homeassistant@glasgownet.com

--- a/packages/device_alerts.yaml
+++ b/packages/device_alerts.yaml
@@ -78,7 +78,15 @@ automation:
             false
             {% endif %}
     action:
+      # continue_on_error so an email delivery outage doesn't repeatedly
+      # fail this automation - the persistent_notification below is the
+      # guaranteed-to-work fallback channel.
       - service: notify.email_kyle
+        continue_on_error: true
+        data:
+          message: '{{trigger.to_state.attributes.friendly_name}} has gone offline. Please check the status of this device as some features may stop functioning.'
+          title: Device Alert
+      - service: persistent_notification.create
         data:
           message: '{{trigger.to_state.attributes.friendly_name}} has gone offline. Please check the status of this device as some features may stop functioning.'
           title: Device Alert

--- a/packages/overflights.yaml
+++ b/packages/overflights.yaml
@@ -18,12 +18,20 @@ automation:
       - condition: template
         value_template: "{{ trigger.event.data.altitude <= 10000 }}"
     action:
+      # continue_on_error so an email delivery outage doesn't repeatedly
+      # fail this automation - the persistent_notification below is the
+      # guaranteed-to-work fallback channel.
       - service: notify.email_kyle
+        continue_on_error: true
         data:
           title: "Overflight event"
           message: 'Flight {{ trigger.event.data.callsign }} is passing nearby at {{ trigger.event.data.altitude }} meters.
 
           https://flightaware.com/live/flight/{{ trigger.event.data.callsign }}'
+      - service: persistent_notification.create
+        data:
+          title: "Overflight event"
+          message: 'Flight {{ trigger.event.data.callsign }} is passing nearby at {{ trigger.event.data.altitude }} meters.'
 
   - alias: 'Flight entry notification - Uplawmoor'
     id: flight_entry_notification_uplawmoor
@@ -34,8 +42,13 @@ automation:
       event_type: opensky_entry
     action:
       - service: notify.email_kyle
+        continue_on_error: true
         data:
           title: "{{ trigger.event.data.callsign }} Overflight - Uplawmoor"
           message: 'Flight {{ trigger.event.data.callsign }} is passing near Uplawmoor at {{ trigger.event.data.altitude }} meters.
 
           https://flightaware.com/live/flight/{{ trigger.event.data.callsign }}'
+      - service: persistent_notification.create
+        data:
+          title: "{{ trigger.event.data.callsign }} Overflight - Uplawmoor"
+          message: 'Flight {{ trigger.event.data.callsign }} is passing near Uplawmoor at {{ trigger.event.data.altitude }} meters.'


### PR DESCRIPTION
## Summary
- home-assistant.log shows three automations failing with `Service not found for call_service at pos 1: Action notify.email_kyle not found`: `automation.flight_entry_notification_home`, `automation.flight_entry_notification_uplawmoor`, `automation.alert_when_a_critical_device_goes_offline`.
- Root cause: `Failed to initialize notification service smtp` at startup — the `smtp` platform's `connection_is_valid()` check failed, so `notify.email_kyle` was never registered as a service at all.
- `notify.yaml`'s `starttls: true` key isn't part of the current smtp schema (replaced by `encryption: starttls`, which happens to already be the default) — cleaned it up, though it wasn't the root cause (it was silently ignored as an extra key, not rejected).
- The actual connection/auth failure isn't visible in the log beyond the one line, and depends on credentials living outside this repo (`secrets.yaml`) — **if this recurs, check the Gmail app-password/account status**, this PR can't fix that part.
- What this PR *does* fix: added `continue_on_error: true` to the `notify.email_kyle` step and a `persistent_notification.create` fallback in both affected packages, so a mail-service outage no longer fails these automations outright — the alert still reaches the user in-app even if email is down.

## Test plan
- [x] `yamllint -c .github/yamllint-config.yml notify.yaml packages/overflights.yaml packages/device_alerts.yaml`
- [x] `check_config` against `homeassistant/home-assistant:stable` in Docker — no new errors vs. baseline
- [ ] Confirm `notify.email_kyle` initializes successfully after the `encryption` key change (needs real credentials/runtime, not verifiable from this PR alone)
- [ ] Confirm persistent notifications appear if the mail service is down again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification reliability when email delivery fails.
  * Added fallback in-app alerts so important events still appear even if email cannot be sent.
  * Updated email notification settings to use the current TLS encryption option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->