### PR TITLE
Fix Camera Snapshot Notification: queue overlapping Frigate events

### DIFF
--- a/automation/camera_snapshot_notification.yaml
+++ b/automation/camera_snapshot_notification.yaml
@@ -1,6 +1,11 @@
 ---
 alias: Camera Snapshot Notification
 id: camera_snapshot_notification
+# Frigate can emit multiple 'new' events in quick succession (e.g. several
+# cameras detecting at once); default single-run mode was dropping the
+# overlapping runs with an "Already running" warning instead of notifying.
+mode: queued
+max: 10
 trigger:
   - platform: mqtt
     topic: "frigate/events"


### PR DESCRIPTION
## Summary
- home-assistant.log shows repeated `Camera Snapshot Notification: Already running` warnings.
- Frigate can fire multiple `new` events in quick succession (e.g. simultaneous detections across cameras); the default `mode: single` was silently dropping the overlapping runs instead of notifying for them.
- Fix: switch to `mode: queued` (max 10) so each event still gets processed instead of being skipped.

## Test plan
- [x] `yamllint -c .github/yamllint-config.yml automation/camera_snapshot_notification.yaml`
- [x] `check_config` against `homeassistant/home-assistant:stable` in Docker — no new errors vs. baseline
- [ ] Confirm no further "Already running" warnings after simultaneous Frigate detections

🤖 Generated with [Claude Code](https://claude.com/claude-code)