### PR TITLE
Fix missing image in camera snapshot notifications

### DIFF
--- a/automation/camera_snapshot_notification.yaml
+++ b/automation/camera_snapshot_notification.yaml
@@ -11,6 +11,8 @@ trigger:
     topic: "frigate/events"
 variables:
   camera: "{{ trigger.payload_json.after.camera | default('unknown') }}"
+  label: "{{ trigger.payload_json.after.label | default('object') }}"
+  snapshot_entity: "camera.{{ camera }}_last_{{ label }}"
 condition:
   - "{{ trigger.payload_json.type == 'end' }}"
 action:
@@ -18,9 +20,12 @@ action:
     data:
       title: "{{ camera | replace('_', ' ') | title }} Snapshot"
       message: >
-        {{ trigger.payload_json.after.label | default('Object') | title }}
+        {{ label | title }}
         detected on {{ camera | replace('_', ' ') | title }}
       data:
         clickAction: "/lovelace/outside"
         url: "/lovelace/outside"
-        image: "/api/frigate/notifications/{{ trigger.payload_json.after.id }}/snapshot.jpg"
+        image: >
+          {% if states(snapshot_entity) not in ['unknown', 'unavailable'] %}
+            /api/camera_proxy/{{ snapshot_entity }}?token={{ state_attr(snapshot_entity, 'access_token') }}
+          {% endif %}


### PR DESCRIPTION
## Summary
- The "Person outside!" notifications attach images fine because they point at `/api/camera_proxy/camera.<x>_last_person?token=...` — the standard HA camera-proxy endpoint with a signed token, for cameras defined as plain MQTT `camera:` entities in `mqtt.yaml`.
- The "... Snapshot" notifications from `automation/camera_snapshot_notification.yaml` instead pointed at `/api/frigate/notifications/<id>/snapshot.jpg`, an endpoint only provided by the Frigate HACS integration — which isn't installed here (Frigate is wired up over raw MQTT only, see `mqtt.yaml`/`custom_components/`). That URL never resolved, so no image ever attached.
- Reworked the automation to build the image URL from the existing `camera.<camera>_last_<label>` MQTT camera entities via `camera_proxy`, same pattern as `packages/outside_lights.yaml`. Falls back to no image if a matching camera entity doesn't exist for that camera/label combo.

## Test plan
- [x] `yamllint -c .github/yamllint-config.yml automation/camera_snapshot_notification.yaml`
- [x] Full HA `check_config` against `homeassistant/home-assistant:stable` — no new errors introduced (pre-existing custom_components-not-found warnings unrelated to this change)
- [ ] Confirm on-device that a Frigate "new" person/car event on back_door/front_door/driveway now attaches an image to the push notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications now display the detected label and camera name dynamically.
  * Snapshot images are selected from the relevant Home Assistant camera entity.
  * Snapshot links are only included when the camera is available.

* **Bug Fixes**
  * Improved snapshot handling by avoiding unavailable or unknown camera entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->