### PR TITLE
Add Zaptec charger cheap-rate charging automation

### DIFF
--- a/packages/zaptec_charging.yaml
+++ b/packages/zaptec_charging.yaml
@@ -1,0 +1,32 @@
+automation:
+  - alias: Zaptec cheap-rate charging start
+    id: zaptec_cheap_rate_charging_start
+    description: Turn on Zaptec charging when the Octopus off-peak window starts.
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.octopus_energy_electricity_22j0090022_1800028864966_off_peak
+        to: "on"
+    action:
+      - service: switch.turn_on
+        target:
+          entity_id: switch.viewpoint_charging
+      - service: notify.mobile_app_nothing_phone_2
+        data:
+          title: "Zaptec charging"
+          message: "Off-peak window started — charging enabled."
+
+  - alias: Zaptec cheap-rate charging stop
+    id: zaptec_cheap_rate_charging_stop
+    description: Turn off Zaptec charging when the Octopus off-peak window ends, even mid-session.
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.octopus_energy_electricity_22j0090022_1800028864966_off_peak
+        to: "off"
+    action:
+      - service: switch.turn_off
+        target:
+          entity_id: switch.viewpoint_charging
+      - service: notify.mobile_app_nothing_phone_2
+        data:
+          title: "Zaptec charging"
+          message: "Off-peak window ended — charging disabled."


### PR DESCRIPTION
## Summary
- Gates `switch.viewpoint_charging` on the Octopus off-peak binary sensor (`binary_sensor.octopus_energy_electricity_22j0090022_1800028864966_off_peak`): charging turns on when the off-peak window starts, off (immediately, even mid-session) when it ends.
- Applies uniformly regardless of which vehicle is plugged in — the Octopus/Polestar Intelligent Dispatch integration is currently disabled, so this is a local-only HA automation, not a dependency on that mechanism.
- Notifies `notify.mobile_app_nothing_phone_2` on each transition, matching the existing `boost_hot_water` / Knockhill charge automation convention.

## Test plan
- [x] `yamllint -c .github/yamllint-config.yml packages/zaptec_charging.yaml` — pass
- [x] Full HA `check_config` against `homeassistant/home-assistant:stable` — `Successful config (all)`, both automations parsed with expected alias/id/trigger/action
- [ ] Manual: confirm `switch.viewpoint_charging` turns on/off in sync with the off-peak sensor across a real (or simulated) off-peak window
- [ ] Manual: confirm the mobile notification arrives on both start and stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Zaptec vehicle charging during Octopus off-peak periods.
  * Charging now stops when the off-peak period ends, including if it ends mid-session.
  * Added mobile notifications when charging starts and stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->