### PR TITLE
Add lawnmower package: keep Luba 2 turnaround mode on multi-point

### DIFF
--- a/packages/lawnmower.yaml
+++ b/packages/lawnmower.yaml
@@ -1,0 +1,18 @@
+---
+automation:
+  - alias: Keep resetting Luba 2 turnaround mode to multi-point
+    id: luba2_turnaround_mode_multipoint
+    description: ""
+    triggers:
+      - trigger: state
+        entity_id:
+          - select.snowball_turnaround_mode
+    conditions: []
+    actions:
+      - action: select.select_option
+        metadata: {}
+        target:
+          entity_id: select.snowball_turnaround_mode
+        data:
+          option: multipoint
+    mode: single


### PR DESCRIPTION
## Summary
- Adds `packages/lawnmower.yaml` with an automation that resets `select.snowball_turnaround_mode` back to `multipoint` whenever it changes state, since the Mammotion Luba 2 periodically resets this on its own.
- Entity name (`select.snowball_turnaround_mode`) verified live against Home Assistant via MCP.

## Test plan
- [x] `yamllint -c .github/yamllint-config.yml packages/lawnmower.yaml` passes
- [x] Verified `select.snowball_turnaround_mode` exists and options are `zero_turn`/`multipoint`
- [ ] Confirm automation fires and correctly resets the mode after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automation that automatically resets the Luba 2 turnaround mode to **Multi-point** whenever the setting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->