### PR TITLE
Prep ESPHome fleet for ESPHome Update Manager

### DIFF
--- a/automation/esphome_deep_sleep_wake_and_update.yaml
+++ b/automation/esphome_deep_sleep_wake_and_update.yaml
@@ -1,0 +1,135 @@
+---
+# Handles ALL deep sleep ESPHome devices. On every wake-up (a normal wake
+# AND the reboot after an ESPHome Update Manager install), the device gets
+# its full awake_window_seconds before being put back to sleep - unless an
+# update is pending/running, in which case it stays awake until that
+# finishes (then still gets its awake_window_seconds before sleeping).
+#
+# Requires each device's deep_sleep block to omit run_duration and expose a
+# button whose friendly name contains "sleep" that calls deep_sleep.enter -
+# see esphome/common/esp8266_dht_sensor_common.yaml and
+# esphome/common/car_battery_monitor_common.yaml.
+#
+# NOTE: the entity_id list below is a best-effort guess at the ESPHome
+# status binary_sensor slugs derived from each device's friendly_name.
+# Verify these against the live instance (Settings > Devices & Services >
+# Entities) before relying on this automation - this repo clone's
+# entity registry does not reflect the deployed instance.
+alias: "ESPHome deep sleep devices - wake and update"
+id: esphome_deep_sleep_wake_and_update
+mode: parallel
+max: 10
+max_exceeded: silent
+variables:
+  awake_window_seconds: 120
+trigger:
+  - id: wake
+    platform: state
+    entity_id:
+      - binary_sensor.land_rover_battery_monitor_status
+      - binary_sensor.volvo_battery_monitor_status
+      - binary_sensor.tr6_battery_monitor_status
+      - binary_sensor.ac_battery_monitor_status
+      - binary_sensor.front_hall_sensor_status
+      - binary_sensor.study_sensor_status
+      - binary_sensor.tin_hut_sensor_status
+    to: "on"
+  - id: finished
+    platform: event
+    event_type: esphome_update_manager_finished
+action:
+  - choose:
+      # Branch 1: a device just woke up
+      - conditions:
+          - condition: trigger
+            id: wake
+        sequence:
+          - variables:
+              wake_last_changed: "{{ trigger.to_state.last_changed }}"
+          - delay: "{{ awake_window_seconds }}"
+          - condition: template
+            # If this is false, the sensor flipped again during our wait
+            # (a reboot happened) - a newer run or the finished-branch is
+            # already handling this device, so stop here silently.
+            value_template: >
+              {{ (states[trigger.entity_id].last_changed | string) == (wake_last_changed | string) }}
+          - service: esphome_update_manager.get_device_status
+            data:
+              device_id: "{{ device_id(trigger.entity_id) }}"
+            response_variable: dev_status
+          - if:
+              - condition: template
+                value_template: >
+                  {{ not dev_status.devices.get(device_id(trigger.entity_id), {}).get('active', false) }}
+            then:
+              - variables:
+                  deep_sleep_btn: >
+                    {% set ns = namespace(found=none) %}
+                    {% for e in states.button
+                       if device_id(e.entity_id) == device_id(trigger.entity_id)
+                       and 'sleep' in (e.attributes.friendly_name | lower) %}
+                      {% set ns.found = e.entity_id %}
+                    {% endfor %}
+                    {{ ns.found }}
+              - if:
+                  - condition: template
+                    value_template: "{{ deep_sleep_btn != none }}"
+                then:
+                  - service: button.press
+                    target:
+                      entity_id: "{{ deep_sleep_btn }}"
+
+      # Branch 2: an update batch just finished (force install or a
+      # regular auto-update / manual update)
+      - conditions:
+          - condition: trigger
+            id: finished
+        sequence:
+          - variables:
+              finished_devices: >
+                {{ trigger.event.data.results
+                   | selectattr('device_id', 'defined')
+                   | list }}
+          - repeat:
+              for_each: "{{ finished_devices }}"
+              sequence:
+                # Wait for the device to come back online after reboot
+                - wait_template: >
+                    {% set ns = namespace(online=false) %}
+                    {% for e in states.binary_sensor
+                       if e.entity_id.endswith('_status')
+                       and device_id(e.entity_id) == repeat.item.device_id %}
+                      {% if e.state == 'on' %}{% set ns.online = true %}{% endif %}
+                    {% endfor %}
+                    {{ ns.online }}
+                  timeout: "00:03:00"
+                  continue_on_timeout: true
+                # Give it its normal awake window
+                - delay: "{{ awake_window_seconds }}"
+                # Final safety check before sleeping, in case something new
+                # got queued for it in the meantime
+                - service: esphome_update_manager.get_device_status
+                  data:
+                    device_id: "{{ repeat.item.device_id }}"
+                  response_variable: dev_status2
+                - if:
+                    - condition: template
+                      value_template: >
+                        {{ not dev_status2.devices.get(repeat.item.device_id, {}).get('active', false) }}
+                  then:
+                    - variables:
+                        deep_sleep_btn: >
+                          {% set ns = namespace(found=none) %}
+                          {% for e in states.button
+                             if device_id(e.entity_id) == repeat.item.device_id
+                             and 'sleep' in (e.attributes.friendly_name | lower) %}
+                            {% set ns.found = e.entity_id %}
+                          {% endfor %}
+                          {{ ns.found }}
+                    - if:
+                        - condition: template
+                          value_template: "{{ deep_sleep_btn != none }}"
+                      then:
+                        - service: button.press
+                          target:
+                            entity_id: "{{ deep_sleep_btn }}"

--- a/automation/esphome_deep_sleep_wake_and_update.yaml
+++ b/automation/esphome_deep_sleep_wake_and_update.yaml
@@ -19,7 +19,6 @@ alias: "ESPHome deep sleep devices - wake and update"
 id: esphome_deep_sleep_wake_and_update
 mode: parallel
 max: 10
-max_exceeded: silent
 variables:
   awake_window_seconds: 120
 trigger:
@@ -64,16 +63,16 @@ action:
             then:
               - variables:
                   deep_sleep_btn: >
-                    {% set ns = namespace(found=none) %}
+                    {% set ns = namespace(found='') %}
                     {% for e in states.button
                        if device_id(e.entity_id) == device_id(trigger.entity_id)
-                       and 'sleep' in (e.attributes.friendly_name | lower) %}
+                       and 'sleep' in (e.attributes.friendly_name | default('') | lower) %}
                       {% set ns.found = e.entity_id %}
                     {% endfor %}
                     {{ ns.found }}
               - if:
                   - condition: template
-                    value_template: "{{ deep_sleep_btn != none }}"
+                    value_template: "{{ deep_sleep_btn != '' }}"
                 then:
                   - service: button.press
                     target:
@@ -87,21 +86,23 @@ action:
         sequence:
           - variables:
               finished_devices: >
-                {{ trigger.event.data.results
+                {{ trigger.event.data.results | default([])
                    | selectattr('device_id', 'defined')
                    | list }}
           - repeat:
               for_each: "{{ finished_devices }}"
               sequence:
+                - variables:
+                    status_entity: >
+                      {% set ns = namespace(found='') %}
+                      {% for e in states.binary_sensor
+                         if e.entity_id.endswith('_status')
+                         and device_id(e.entity_id) == repeat.item.device_id %}
+                        {% set ns.found = e.entity_id %}
+                      {% endfor %}
+                      {{ ns.found }}
                 # Wait for the device to come back online after reboot
-                - wait_template: >
-                    {% set ns = namespace(online=false) %}
-                    {% for e in states.binary_sensor
-                       if e.entity_id.endswith('_status')
-                       and device_id(e.entity_id) == repeat.item.device_id %}
-                      {% if e.state == 'on' %}{% set ns.online = true %}{% endif %}
-                    {% endfor %}
-                    {{ ns.online }}
+                - wait_template: "{{ status_entity != '' and is_state(status_entity, 'on') }}"
                   timeout: "00:03:00"
                   continue_on_timeout: true
                 # Give it its normal awake window
@@ -119,16 +120,16 @@ action:
                   then:
                     - variables:
                         deep_sleep_btn: >
-                          {% set ns = namespace(found=none) %}
+                          {% set ns = namespace(found='') %}
                           {% for e in states.button
                              if device_id(e.entity_id) == repeat.item.device_id
-                             and 'sleep' in (e.attributes.friendly_name | lower) %}
+                             and 'sleep' in (e.attributes.friendly_name | default('') | lower) %}
                             {% set ns.found = e.entity_id %}
                           {% endfor %}
                           {{ ns.found }}
                     - if:
                         - condition: template
-                          value_template: "{{ deep_sleep_btn != none }}"
+                          value_template: "{{ deep_sleep_btn != '' }}"
                       then:
                         - service: button.press
                           target:

--- a/esphome/common/car_battery_monitor_common.yaml
+++ b/esphome/common/car_battery_monitor_common.yaml
@@ -35,7 +35,6 @@ logger:
 
 deep_sleep:
   id: deep_sleep_1
-  run_duration: 20s
   sleep_duration: 10min
 
 binary_sensor:
@@ -108,6 +107,13 @@ light:
     id: blue_led_light
     name: "${friendly_name} Status LED"
     output: blue_led
+
+button:
+  - platform: template
+    name: "${friendly_name} Enter Deep Sleep"
+    icon: mdi:sleep
+    on_press:
+      - deep_sleep.enter: deep_sleep_1
 
 # Consolidated LED status indicator - checks WiFi, API, and OTA status
 script:

--- a/esphome/common/car_battery_monitor_common.yaml
+++ b/esphome/common/car_battery_monitor_common.yaml
@@ -35,6 +35,10 @@ logger:
 
 deep_sleep:
   id: deep_sleep_1
+  # Failsafe only - the wake automation presses the deep sleep button well
+  # before this in normal operation. Bounds awake time (battery drain) if
+  # Home Assistant is unreachable when the device wakes.
+  run_duration: 10min
   sleep_duration: 10min
 
 binary_sensor:

--- a/esphome/common/esp8266_dht_sensor_common.yaml
+++ b/esphome/common/esp8266_dht_sensor_common.yaml
@@ -35,7 +35,6 @@ web_server:
 
 deep_sleep:
   id: deep_sleep_1
-  run_duration: 60s
   sleep_duration: 300s
 
 i2c:
@@ -83,6 +82,13 @@ light:
     id: blue_led_light
     name: "${friendly_name} Blue LED"
     output: blue_led
+
+button:
+  - platform: template
+    name: "${friendly_name} Enter Deep Sleep"
+    icon: mdi:sleep
+    on_press:
+      - deep_sleep.enter: deep_sleep_1
 
 # Blink the light if we aren't connected to WiFi.
 interval:

--- a/esphome/common/esp8266_dht_sensor_common.yaml
+++ b/esphome/common/esp8266_dht_sensor_common.yaml
@@ -35,6 +35,10 @@ web_server:
 
 deep_sleep:
   id: deep_sleep_1
+  # Failsafe only - the wake automation presses the deep sleep button well
+  # before this in normal operation. Bounds awake time (battery drain) if
+  # Home Assistant is unreachable when the device wakes.
+  run_duration: 10min
   sleep_duration: 300s
 
 i2c:

--- a/esphome/everything-presence-lite-kitchen.yaml
+++ b/esphome/everything-presence-lite-kitchen.yaml
@@ -16,3 +16,7 @@ api:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+
+binary_sensor:
+  - platform: status
+    name: "${friendly_name} Status"

--- a/esphome/everything-presence-lite-living-room.yaml
+++ b/esphome/everything-presence-lite-living-room.yaml
@@ -16,3 +16,7 @@ api:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+
+binary_sensor:
+  - platform: status
+    name: "${friendly_name} Status"

--- a/esphome/everything-presence-lite-tin-hut.yaml
+++ b/esphome/everything-presence-lite-tin-hut.yaml
@@ -16,3 +16,7 @@ api:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+
+binary_sensor:
+  - platform: status
+    name: "${friendly_name} Status"


### PR DESCRIPTION
## Summary

Following the deployment of [ESPHome Update Manager](https://github.com/KriVaTri/ESPHome-Update-Manager), this brings the fleet in line with what it expects for reliable status detection and battery-device auto-updates:

- **Status binary_sensor**: `common/common.yaml` already provides this fleet-wide for 59/67 devices, and the Konnected alarm boards already pick it up transitively via `common/alarm-panel-esp8266.yaml`. The 3 Everything Presence Lite devices (kitchen/living-room/tin-hut) use an external vendor package that doesn't include one, so it's added directly to each device file.
- **Deep sleep devices** (4 car battery monitors, front hall/study/tin-hut sensors): removed `run_duration` from their `deep_sleep:` blocks and added a dedicated "Enter Deep Sleep" template button, per the [Deep sleep devices](https://github.com/KriVaTri/ESPHome-Update-Manager#deep-sleep-devices) requirements — the manager's wake automation needs to control the awake window itself rather than racing a device-side timer.
- **New automation** (`automation/esphome_deep_sleep_wake_and_update.yaml`): adapted from the manager's README to auto-update/force-install these 7 battery devices on wake, then let them go back to sleep.

## Notes / follow-ups

- ⚠️ The `entity_id` list in the new automation is a best-effort guess at each device's status sensor slug (derived from `friendly_name`) — this dev clone's `.storage/` doesn't reflect the live instance's entity registry, so **please verify these 7 entity_ids against the real instance** before relying on the automation.
- The existing `input_boolean.esphome_ota_enable` prevent/enter pattern in these devices is left in place and still works as a manual "stay awake" override — it's independent of the new button-based flow.
- Removing `run_duration` means these battery devices will now stay awake indefinitely if the new automation doesn't fire (e.g. HA is down when they wake) — worth keeping an eye on battery drain after this ships, since there's no device-side fallback timeout anymore.
- The 3 Konnected alarm boards and non-deep-sleep devices needed no changes.

## Test plan

- [x] `yamllint -c .github/yamllint-config.yml` on all touched files — clean
- [x] Home Assistant `check_config` (stable image) — `Successful config (all)`, automation parses correctly
- [x] `esphome config` validation for all 5 directly-touched device YAMLs — `Configuration is valid!`
- [ ] Verify the 7 status-sensor entity_ids in the new automation against the live instance
- [ ] Confirm the deep-sleep button appears and works on a real device after OTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated handling for device wake-ups and completed update cycles, including safe return to deep sleep.
  * Added an “Enter Deep Sleep” control for supported devices.
  * Added status sensors for kitchen, living room and tin hut presence devices.
* **Improvements**
  * Extended the deep-sleep failsafe window to 10 minutes for more reliable operation.
  * Improved update handling by waiting for devices to reconnect before returning to sleep.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->