### PR TITLE
Enable recorder history for Average External Light Level, fix to mean

### DIFF
--- a/recorder.yaml
+++ b/recorder.yaml
@@ -111,4 +111,3 @@ exclude:
     - media_player.living_room
     - sensor.hot_tap_power
     - sensor.hot_tap_voltage
-    - sensor.average_external_light_level

--- a/sensors.yaml
+++ b/sensors.yaml
@@ -2,7 +2,7 @@
 - platform: min_max
   name: Average External Light Level
   unique_id: average_external_light_level
-  type: median
+  type: mean
   entity_ids:
     - sensor.lux_meter_1_level
     - sensor.lux_meter_2_level


### PR DESCRIPTION
## Summary
- `sensor.average_external_light_level` was excluded from the recorder in `recorder.yaml`, so History never had any data to graph. Removed that exclusion — the three noisy raw `sensor.lux_meter_*_level` inputs stay excluded via the existing `entity_globs` rule (they generate 218K-258K records/day each), but the single derived value is cheap to record.
- Changed the `min_max` sensor's `type` from `median` to `mean` in `sensors.yaml` so it actually computes an average, matching its friendly name.

## Test plan
- [x] `yamllint -c .github/yamllint-config.yml sensors.yaml recorder.yaml` — clean
- [x] `homeassistant/home-assistant:stable` `check_config --info all` — successful config, only pre-existing unrelated custom_components warnings
- [ ] After deploy, confirm History shows a graph for Average External Light Level going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Average External Light Level data is now retained in the recorder for historical tracking.

- **Bug Fixes**
  - Updated the Average External Light Level calculation to use the mean of configured readings instead of the median.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->