### PR TITLE
Remove dead rfxtrx PIR sensors from outside light triggers

### DIFF
--- a/packages/outside_lights.yaml
+++ b/packages/outside_lights.yaml
@@ -41,8 +41,6 @@ automation:
     trigger:
       - platform: state
         entity_id:
-          - binary_sensor.back_door_pir
-          - binary_sensor.driveway_pir
           - binary_sensor.driveway_person_occupancy
           - binary_sensor.driveway_tin_hut_person_occupancy
           - binary_sensor.back_door_person_occupancy
@@ -115,8 +113,6 @@ automation:
     trigger:
       - platform: state
         entity_id:
-          - binary_sensor.back_door_pir
-          - binary_sensor.driveway_pir
           - binary_sensor.driveway_person_occupancy
           - binary_sensor.driveway_tin_hut_person_occupancy
           - binary_sensor.back_door_person_occupancy
@@ -177,8 +173,6 @@ automation:
     trigger:
       - platform: state
         entity_id:
-          - binary_sensor.back_door_pir
-          - binary_sensor.driveway_pir
           - binary_sensor.front_door_motion
           - binary_sensor.back_door_person_occupancy
           - binary_sensor.driveway_person_occupancy


### PR DESCRIPTION
`binary_sensor.back_door_pir` and `binary_sensor.driveway_pir` are two 433 MHz rfxtrx PIRs that have stopped working and are **due for physical deinstall**. This removes them from the three automation trigger lists in `packages/outside_lights.yaml`.

## Why now

Neither PIR has changed state once in the last 10 days, while the co-located Frigate `_person_occupancy` sensors covering the same locations logged 330 state changes over the same window. The removal is therefore behaviour-neutral on the live instance — these triggers are already contributing nothing.

## What changes

Six deleted lines, nothing else. The two entity IDs come out of the trigger `entity_id` lists of:

| Automation | Triggers retained |
|---|---|
| `outside_person_detected` | 5 × `_person_occupancy` (driveway, driveway_tin_hut, back_door, gates, front_door) |
| `outside_lights_on` | same 5 × `_person_occupancy` |
| `outside_lights_off` | `front_door_motion` + 4 × `_person_occupancy` |

All three keep working triggers. `to:` and `for:` values, aliases, ids, conditions, actions, `mode` and formatting are untouched.

The notification `image:` templates in the two "on" automations branch on substrings of `trigger.entity_id` (`'back_door'`, `'front_door'`, `'driveway'`, `'gates'`) — every remaining trigger entity ID still carries its branch substring, so no branch goes dead. (A PIR-fired notification would previously have attached a *Frigate* snapshot the PIR did not produce, so this also removes a potential stale-image mismatch.)

## Validation

- `yamllint -c .github/yamllint-config.yml` over all tracked YAML — clean
- Dockerised `check_config` against `homeassistant/home-assistant:stable` — no errors; all three automations load with exactly the expected trigger sets

## Not in this PR — follow-up steps I'll do myself

1. Physically deinstall the two PIRs.
2. Delete the two rfxtrx devices (`966a7505af8e4516b3a3936742fdd147`, `80990fa8a1224a56ab29117c0c6f8877`) and their 8 entities. The rfxtrx integration itself stays — 18 other devices depend on it.
3. Remove the two now-orphaned rows from the live Lovelace "Motion Sensors" card (dashboards are storage-mode, not in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the outside lighting automations to respond to person-occupancy detection from the driveway, tin hut, and back door.
  - Outside lights now switch on based on the updated occupancy sensors, alongside the existing gates and front door sensors.
  - Outside lights now switch off based on front door motion and the updated occupancy sensors.
  - Removed the previous back door and driveway PIR sensor triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->