### PR TITLE
Drive outside lights from Frigate events, not occupancy toggling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,18 @@
 ## Special Instructions for Copilot
 Whenever you run a command in the terminal, pipe the output to a file, output.txt, that you can read from. Make sure to overwrite each time so that it doesn't grow too big. There is a bug in the current version of Copilot that causes it to not read the output of commands correctly. This workaround allows you to read the output from the temporary file instead.
 
+## Your Role
+
+Act as a **Home Assistant expert** with deep, working knowledge of:
+
+- **Home Assistant** - the config schema, integrations, entity/device/area model, automations and scripts (triggers, conditions, actions, `mode:`), template sensors, helpers, blueprints, the `alert:` integration, and packages. Know when a native feature (e.g. `alert:`, `for:`, trigger IDs, `to`/`from` filters) replaces a hand-rolled workaround, and prefer it.
+- **Jinja2 templating** as HA uses it - `states()`, `state_attr()`, `is_state()`, `expand()`, `now()`, availability templates, and the difference between a template that errors and one that returns `unknown`/`unavailable`.
+- **Python** - for reading and fixing the integrations under `custom_components/`, and for understanding upstream HA core behaviour when a config change trips a schema or deprecation.
+- **YAML** - anchors/aliases, block vs flow style, quoting rules, and the ways HA's loader diverges from plain YAML (`!include*`, `!secret`).
+- **ESPHome** - device YAML, components, substitutions, lambdas (C++), scripts, and the `!include` sharing pattern used under `esphome/common/`.
+
+Work from what this repo actually contains rather than from generic HA advice: check the existing package or device file that covers a room or feature and follow its pattern. Verify entity IDs and integration options against the live instance or current HA docs before relying on them - this config spans many HA versions and some older patterns here are deprecated upstream.
+
 ## Repository Overview
 
 This is a **Home Assistant configuration repository** (27MB, 221 YAML files) for a comprehensive smart home deployment. It is **NOT a software development project** - it's a declarative configuration repository for Home Assistant deployed via Docker Compose.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -218,6 +218,16 @@ Energy tracking with multiple cycles:
 - Source: `sensor.energy_spent`
 - Separate meters for TV energy consumption
 
+### Motion Detection: Trigger on Events, Not Binary Sensors
+
+Where a motion source exposes discrete detections as well as a level, trigger on the detections. A `binary_sensor` meaning "something is present right now" is a **level**: while it is already `on`, a further detection produces no state change, and a tracker that momentarily loses its subject produces a spurious `off`. Frigate's `binary_sensor.<camera>_<object>_occupancy` sensors flicker badly for this reason - several on/off cycles for a single visit.
+
+- **Frigate** - trigger on MQTT topic `frigate/events` and filter on `trigger.payload_json`: `type` (`new` / `update` / `end`), `after.label`, `after.camera`. See `packages/outside_lights.yaml` and `automation/camera_snapshot_notification.yaml`. `after.camera` is always a **camera**, never a Frigate zone; zone occupancy is a subset of its parent camera's, so trigger on the camera. Snapshot images come from the `frigate/<camera>/<object>/snapshot` MQTT cameras in `mqtt.yaml`.
+- **"Still active?" and "how long since the last detection?"** are not questions events answer on their own. Hold the state in a `timer` helper that each detection restarts, and act on `timer.finished` - not on `to: 'off'` with a `for:`, which fires when any *one* sensor in a trigger list goes clear.
+- Reading an occupancy `binary_sensor` in a **condition** is fine and often correct; it is only unreliable as a **trigger**.
+- Sources with no event form - Zigbee/zigbee2mqtt occupancy, mmWave presence, ESPHome PIRs - stay on state triggers. There is nothing better available for them.
+- Repeated notifications about the same subject should reuse one notification via a `tag` plus a `timeout` reuse bound, rather than stacking.
+
 ### Integrations
 - **InfluxDB** - Time-series data (energy, sensors) at 172.24.32.13:8086
 - **MQTT** - Zigbee2MQTT integration (see `mqtt.yaml`)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -227,6 +227,7 @@ Where a motion source exposes discrete detections as well as a level, trigger on
 - Reading an occupancy `binary_sensor` in a **condition** is fine and often correct; it is only unreliable as a **trigger**.
 - Sources with no event form - Zigbee/zigbee2mqtt occupancy, mmWave presence, ESPHome PIRs - stay on state triggers. There is nothing better available for them.
 - Repeated notifications about the same subject should reuse one notification via a `tag` plus a `timeout` reuse bound, rather than stacking.
+- A `timer` that outlives a restart needs `restore: true` **and** a `homeassistant` start reconciliation automation. `restore: true` resumes a timer that was still running, but a timer that *expired* during the outage fires `timer.finished` while the timer component is being set up - automations arm their triggers in a startup job that runs after every `EVENT_HOMEASSISTANT_START` listener, so nothing hears it. A `platform: homeassistant, event: start` trigger is safe from that race (it listens for `EVENT_HOMEASSISTANT_STARTED`, fired after automations are armed), but give device-backed entities a short `delay:` to reconnect before reading their state.
 
 ### Integrations
 - **InfluxDB** - Time-series data (energy, sensors) at 172.24.32.13:8086

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,18 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Your role
+
+Act as a **Home Assistant expert** with deep, working knowledge of:
+
+- **Home Assistant** — the config schema, integrations, entity/device/area model, automations and scripts (triggers, conditions, actions, `mode:`), template sensors, helpers, blueprints, the `alert:` integration, packages, and the include directives below. Know when a native feature (e.g. `alert:`, `for:`, trigger IDs, `to`/`from` filters) replaces a hand-rolled workaround, and prefer it.
+- **Jinja2 templating** as HA uses it — `states()`, `state_attr()`, `is_state()`, `expand()`, `now()`, availability templates, and the difference between a template that errors and one that returns `unknown`/`unavailable`.
+- **Python** — for reading and fixing the integrations under `custom_components/`, and for understanding upstream HA core behaviour when a config change trips a schema or deprecation.
+- **YAML** — anchors/aliases, block vs flow style, quoting rules, and the ways HA's loader diverges from plain YAML (`!include*`, `!secret`).
+- **ESPHome** — device YAML, components, substitutions, lambdas (C++), scripts, and the `!include` sharing pattern used under `esphome/common/`.
+
+Work from what this repo actually contains rather than from generic HA advice: check the existing package/device that covers a room or feature and follow its pattern. Verify entity IDs and integration options against the live instance or current HA docs before relying on them — this config spans many HA versions and some older patterns here are deprecated upstream.
+
 ## Repository overview
 
 This is a **Home Assistant configuration repository**, not a software project. It's a declarative YAML configuration for a real smart home, deployed via Docker Compose (see https://github.com/kylegordon/ha-stack). There is no build step — "development" means editing YAML and validating it against real Home Assistant / ESPHome binaries in Docker.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,16 @@ TX-Ultimate-Easy touch switches (`*_switch.yaml`) are a significant device famil
 
 The Somfy RTS garage/tin-hut door control (`tin_hut_door_left.yaml` / `tin_hut_door_right.yaml`) shares state-machine logic from `esphome/common/tin-hut-doors.yaml` — it models a single-relay cover as a stop/open/close cycle with time-based position tracking, not true position control.
 
+### Motion detection: trigger on events, not on binary sensors
+
+Where a motion source exposes discrete detections as well as a level, trigger on the detections. A `binary_sensor` that means "something is present right now" is a *level*: while it is already `on`, a further detection produces no state change, and a tracker that momentarily loses its subject produces a spurious `off`. Frigate's `binary_sensor.<camera>_<object>_occupancy` sensors flicker badly for this reason — several on/off cycles for a single visit.
+
+- **Frigate** — trigger on MQTT topic `frigate/events` and filter on `trigger.payload_json`: `type` (`new` / `update` / `end`), `after.label`, `after.camera`. See `packages/outside_lights.yaml` and `automation/camera_snapshot_notification.yaml`. Note that `after.camera` is always a *camera*, never a Frigate zone; zone occupancy is a subset of its parent camera's, so trigger on the camera. Snapshot images come from the `frigate/<camera>/<object>/snapshot` MQTT cameras in `mqtt.yaml`.
+- **"Still active?" and "how long since the last detection?"** are not questions events answer on their own. Hold the state in a `timer` helper that each detection restarts, and act on `timer.finished` — not on `to: 'off'` with a `for:`, which fires when any *one* sensor in a trigger list goes clear.
+- Reading an occupancy `binary_sensor` in a **condition** is fine and often correct; it is only unreliable as a **trigger**.
+- Sources with no event form — Zigbee/zigbee2mqtt occupancy, mmWave presence, ESPHome PIRs — stay on state triggers. There is nothing better available for them.
+- Repeated notifications about the same subject should reuse one notification via a `tag` plus a `timeout` reuse bound, rather than stacking.
+
 ### Custom components
 
 `custom_components/` holds integrations not available (or not current) in HACS/core: `hwam_stove` (wood stove, needs `pystove==0.3a1`), `adaptive_lighting`, `programmable_thermostat`, `thermal_comfort`, `bulb_energy`, `smartir`, `alexa_media`, plus `hacs` itself. This directory is excluded from yamllint and remark lint.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ Where a motion source exposes discrete detections as well as a level, trigger on
 - Reading an occupancy `binary_sensor` in a **condition** is fine and often correct; it is only unreliable as a **trigger**.
 - Sources with no event form — Zigbee/zigbee2mqtt occupancy, mmWave presence, ESPHome PIRs — stay on state triggers. There is nothing better available for them.
 - Repeated notifications about the same subject should reuse one notification via a `tag` plus a `timeout` reuse bound, rather than stacking.
+- A `timer` that outlives a restart needs `restore: true` **and** a `homeassistant` start reconciliation automation. `restore: true` resumes a timer that was still running, but a timer that *expired* during the outage fires `timer.finished` while the timer component is being set up — automations arm their triggers in a startup job that runs after every `EVENT_HOMEASSISTANT_START` listener, so nothing hears it. A `platform: homeassistant, event: start` trigger is safe from that race (it listens for `EVENT_HOMEASSISTANT_STARTED`, fired after automations are armed), but give device-backed entities a short `delay:` to reconnect before reading their state.
 
 ### Custom components
 

--- a/mqtt.yaml
+++ b/mqtt.yaml
@@ -75,6 +75,11 @@ camera:
     topic: frigate/front_door/person/snapshot
   - name: Driveway Last Person
     topic: frigate/driveway/person/snapshot
+  # The driveway_tin_hut camera had no snapshot entity, so notifications for it
+  # fell back to the driveway camera's image (via a substring match on the
+  # trigger entity_id). Frigate publishes a snapshot topic per camera+object.
+  - name: Driveway Tin Hut Last Person
+    topic: frigate/driveway_tin_hut/person/snapshot
   - name: Driveway Last Car
     topic: frigate/driveway/car/snapshot
   - name: octoPrint camera

--- a/packages/outside_lights.yaml
+++ b/packages/outside_lights.yaml
@@ -35,19 +35,66 @@ template:
               - 0
               - 0
 
+timer:
+  outside_lights_hold:
+    name: Outside lights hold
+    icon: mdi:timer-outline
+    # How long the outside lights stay on after the most recent person
+    # detection on any watched camera. Every detection restarts it, so the
+    # window is measured from the last detection rather than the first.
+    duration: "00:05:00"
+    # Survive a Home Assistant restart. Without this a restart mid-hold would
+    # lose the timer and leave the lights on until something else turned them
+    # off; with it, a hold that expired while HA was down fires timer.finished
+    # on startup instead.
+    restore: true
+
 automation:
+  # ---------------------------------------------------------------------------
+  # Frigate's occupancy binary sensors are levels, not events.
+  # binary_sensor.<camera>_person_occupancy means "a person object is being
+  # tracked here right now", and the tracker loses and reacquires objects
+  # constantly: on 2026-09-03 the driveway sensor went on and off six times in
+  # four minutes for what was one visit. A `to: 'on'` state trigger therefore
+  # fires once per reacquisition rather than once per arrival, and a `to: 'off'`
+  # trigger reports "gone" every time tracking stutters.
+  #
+  # frigate/events carries the detections themselves — one message per stage of
+  # a tracked object's life (type: new / update / end) — which is what these
+  # automations actually want. Same source as
+  # automation/camera_snapshot_notification.yaml.
+  #
+  # Cameras, not zones: 'gates' is a zone on the driveway_tin_hut camera, and
+  # 'road' / 'parking_area_-_driveway' / 'parking_area_-_tin_hut' are zones on
+  # driveway and driveway_tin_hut. Their occupancy is a subset of the parent
+  # camera's, so watching the four cameras covers everything the old five-sensor
+  # trigger list covered. The frigate/events payload reports after.camera and
+  # never a zone name, so a zone would not match here anyway.
+  # ---------------------------------------------------------------------------
+
   - alias: Outside person detected
     id: outside_person_detected
+    # Every frigate/events message wakes this automation and most are rejected
+    # by the conditions below; several cameras can also fire at once. Queue the
+    # runs rather than dropping them with an "already running" warning.
+    mode: queued
+    max: 10
     trigger:
-      - platform: state
-        entity_id:
-          - binary_sensor.driveway_person_occupancy
-          - binary_sensor.driveway_tin_hut_person_occupancy
-          - binary_sensor.back_door_person_occupancy
-          - binary_sensor.gates_person_occupancy
-          - binary_sensor.front_door_person_occupancy
-        to: 'on'
+      - platform: mqtt
+        topic: "frigate/events"
+    variables:
+      # Shared with Outside lights on via the YAML anchor — edit here only.
+      cameras: &outside_person_cameras
+        - back_door
+        - driveway
+        - driveway_tin_hut
+        - front_door
+      camera: "{{ trigger.payload_json.after.camera | default('unknown') }}"
+      snapshot_entity: "camera.{{ camera }}_last_person"
     condition:
+      - "{{ trigger.payload_json.type == 'new' }}"
+      - "{{ trigger.payload_json.after.label == 'person' }}"
+      - "{{ camera in cameras }}"
       - condition: state
         entity_id: sun.sun
         state: "above_horizon"
@@ -56,19 +103,19 @@ automation:
         data:
           title: "Person outside!"
           message: >
-            Person detected outside by {{ trigger.to_state.attributes.friendly_name }}
+            Person detected outside by {{ camera | replace('_', ' ') | title }}
           data:
+            # One tracked person can still end and restart as several objects,
+            # so repeated detections on the same camera update a single
+            # notification in place instead of stacking near-identical ones.
+            # Same tag+timeout reuse bound as camera_snapshot_notification.
+            tag: "outside_person:{{ camera }}"
+            timeout: 900
             clickAction: "/lovelace/outside"
             url: "/lovelace/outside"
             image: >
-              {% if 'back_door' in trigger.entity_id %}
-                /api/camera_proxy/camera.back_door_last_person?token={{ state_attr('camera.back_door_last_person','access_token') }}
-              {% elif 'front_door' in trigger.entity_id %}
-                /api/camera_proxy/camera.front_door_last_person?token={{ state_attr('camera.front_door_last_person','access_token') }}
-              {% elif 'driveway' in trigger.entity_id %}
-                /api/camera_proxy/camera.driveway_last_person?token={{ state_attr('camera.driveway_last_person','access_token') }}
-              {% elif 'gates' in trigger.entity_id %}
-                /api/camera_proxy/camera.driveway_last_person?token={{ state_attr('camera.driveway_last_person','access_token') }}
+              {% if states(snapshot_entity) not in ['unknown', 'unavailable'] %}
+                /api/camera_proxy/{{ snapshot_entity }}?token={{ state_attr(snapshot_entity, 'access_token') }}
               {% endif %}
 
 
@@ -110,16 +157,29 @@ automation:
 
   - alias: Outside lights on
     id: outside_lights_on
+    mode: queued
+    max: 10
     trigger:
-      - platform: state
-        entity_id:
-          - binary_sensor.driveway_person_occupancy
-          - binary_sensor.driveway_tin_hut_person_occupancy
-          - binary_sensor.back_door_person_occupancy
-          - binary_sensor.gates_person_occupancy
-          - binary_sensor.front_door_person_occupancy
-        to: 'on'
+      - platform: mqtt
+        topic: "frigate/events"
+    variables:
+      cameras: *outside_person_cameras
+      camera: "{{ trigger.payload_json.after.camera | default('unknown') }}"
+      snapshot_entity: "camera.{{ camera }}_last_person"
+      # An arrival is a detection that starts a visit. If the hold timer is
+      # already running this is a continuation — the tracker reacquiring the
+      # same person, a second camera picking them up, or the object ending —
+      # so the chime and the notification are skipped.
+      arrival: >
+        {{ trigger.payload_json.type == 'new'
+           and not is_state('timer.outside_lights_hold', 'active') }}
     condition:
+      # 'update' and 'end' are accepted as well as 'new' so that a person who
+      # lingers keeps extending the hold, and so the window after they leave is
+      # measured from the object ending rather than from when it first appeared.
+      - "{{ trigger.payload_json.type in ['new', 'update', 'end'] }}"
+      - "{{ trigger.payload_json.after.label == 'person' }}"
+      - "{{ camera in cameras }}"
       - condition: state
         entity_id: input_boolean.night_view
         state: "off"
@@ -127,6 +187,20 @@ automation:
         entity_id: sun.sun
         state: "below_horizon"
     action:
+      # Restart the hold before anything else, so a burst of detections always
+      # extends the window instead of racing Outside lights off.
+      - service: timer.start
+        target:
+          entity_id: timer.outside_lights_hold
+      # light.front_floodlights is a member of the light.outside_lights group
+      # (see lights.yaml), so it comes on with the rest of the group.
+      - service: homeassistant.turn_on
+        entity_id:
+          - light.outside_lights
+      # If this evaluates to false, the action will stop here: the lights are
+      # already on and held, and only the announcement is arrival-only.
+      - condition: template
+        value_template: "{{ arrival }}"
       - service: media_player.play_media
         target:
           entity_id:
@@ -136,55 +210,55 @@ automation:
         data:
           media_content_id: amzn_sfx_doorbell_chime_02
           media_content_type: sound
-      - service: homeassistant.turn_on
-        entity_id:
-          - light.outside_lights
       - service: notify.mobile_app_nothing_phone_2
         data:
           title: "Person outside!"
           message: >
-            Person detected outside by {{ trigger.to_state.attributes.friendly_name }}
+            Person detected outside by {{ camera | replace('_', ' ') | title }}
             Turning on outside lights
           data:
+            tag: "outside_person:{{ camera }}"
+            timeout: 900
             clickAction: "/lovelace/outside"
             url: "/lovelace/outside"
             image: >
-              {% if 'back_door' in trigger.entity_id %}
-                /api/camera_proxy/camera.back_door_last_person?token={{ state_attr('camera.back_door_last_person','access_token') }}
-              {% elif 'front_door' in trigger.entity_id %}
-                /api/camera_proxy/camera.front_door_last_person?token={{ state_attr('camera.front_door_last_person','access_token') }}
-              {% elif 'driveway' in trigger.entity_id %}
-                /api/camera_proxy/camera.driveway_last_person?token={{ state_attr('camera.driveway_last_person','access_token') }}
-              {% elif 'gates' in trigger.entity_id %}
-                /api/camera_proxy/camera.driveway_last_person?token={{ state_attr('camera.driveway_last_person','access_token') }}
+              {% if states(snapshot_entity) not in ['unknown', 'unavailable'] %}
+                /api/camera_proxy/{{ snapshot_entity }}?token={{ state_attr(snapshot_entity, 'access_token') }}
               {% endif %}
-
-      - service: homeassistant.turn_on
-        entity_id:
-          - light.outside_lights
-      # If this evaluates to false, the action will stop here.
-      - condition: template
-        value_template: "{{ not is_state('binary_sensor.home_occupied') }}"
-      - service: light.turn_on
-        entity_id: light.front_floodlights
 
   - alias: Outside lights off
     id: outside_lights_off
+    # Driven by the hold timer rather than by each sensor's own `to: 'off'`.
+    # The old trigger list turned the lights off five minutes after *any one*
+    # camera went clear, even while another still had a person in frame, and
+    # counted a momentary tracking stutter as the person having left.
     trigger:
-      - platform: state
-        entity_id:
-          - binary_sensor.front_door_motion
-          - binary_sensor.back_door_person_occupancy
-          - binary_sensor.driveway_person_occupancy
-          - binary_sensor.driveway_tin_hut_person_occupancy
-          - binary_sensor.gates_person_occupancy
-        to: 'off'
-        for:
-          seconds: 300
+      - platform: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.outside_lights_hold
     action:
-      - service: homeassistant.turn_off
-        entity_id:
-          - light.outside_lights
+      # Someone standing still can outlast the hold if Frigate stops emitting
+      # events for them, so re-arm rather than going dark on a person who is
+      # demonstrably still there. Occupancy is read as a level here, which is
+      # what it is good for — it is only unreliable as a trigger.
+      - if:
+          - condition: state
+            entity_id:
+              - binary_sensor.back_door_person_occupancy
+              - binary_sensor.driveway_person_occupancy
+              - binary_sensor.driveway_tin_hut_person_occupancy
+              - binary_sensor.front_door_person_occupancy
+            state: "on"
+            match: any
+        then:
+          - service: timer.start
+            target:
+              entity_id: timer.outside_lights_hold
+        else:
+          - service: homeassistant.turn_off
+            entity_id:
+              - light.outside_lights
 
   - alias: Front Hall Outside lights toggle
     id: front_hall_outside_lights_toggle

--- a/packages/outside_lights.yaml
+++ b/packages/outside_lights.yaml
@@ -43,10 +43,15 @@ timer:
     # detection on any watched camera. Every detection restarts it, so the
     # window is measured from the last detection rather than the first.
     duration: "00:05:00"
-    # Survive a Home Assistant restart. Without this a restart mid-hold would
-    # lose the timer and leave the lights on until something else turned them
-    # off; with it, a hold that expired while HA was down fires timer.finished
-    # on startup instead.
+    # Survive a Home Assistant restart, so a hold that is still running when HA
+    # goes down resumes instead of being lost.
+    #
+    # A hold that *expired* during the outage is a separate case and this alone
+    # does not cover it. The timer entity does fire timer.finished as it
+    # restores, but that happens while the timer component is being set up, and
+    # automations arm their triggers in a startup job that runs after every
+    # EVENT_HOMEASSISTANT_START listener — so nothing is listening yet and the
+    # event is missed. Outside lights startup reconcile handles that case.
     restore: true
 
 automation:
@@ -259,6 +264,42 @@ automation:
           - service: homeassistant.turn_off
             entity_id:
               - light.outside_lights
+
+  - alias: Outside lights startup reconcile
+    id: outside_lights_startup_reconcile
+    # Covers the one case Outside lights off cannot see: a hold that ran out
+    # while Home Assistant was stopped. Its timer.finished is fired during
+    # component setup, before any automation has armed its triggers, so without
+    # this a restart mid-hold would leave the outside lights on indefinitely.
+    #
+    # The homeassistant start trigger is safe from the same race — it listens
+    # for EVENT_HOMEASSISTANT_STARTED, which fires after automations are armed.
+    trigger:
+      - platform: homeassistant
+        event: start
+    condition:
+      # A hold that restored with time left on it is still running and will
+      # finish on its own. Only an expired or absent hold needs reconciling.
+      - condition: state
+        entity_id: timer.outside_lights_hold
+        state: idle
+    action:
+      # Members of light.outside_lights reconnect at their own pace, so let the
+      # group settle before reading it rather than mistaking a member that has
+      # not reported yet for lights that are already off.
+      - delay: "00:01:00"
+      # If this evaluates to false, the action will stop here: nothing is on,
+      # so there is nothing to reconcile.
+      - condition: state
+        entity_id: light.outside_lights
+        state: "on"
+      # Hand back to the normal path instead of duplicating it. This arms a
+      # fresh hold, and Outside lights off then applies its usual occupancy
+      # check when that hold expires — so a person still outside at restart
+      # keeps the lights, and an empty driveway loses them.
+      - service: timer.start
+        target:
+          entity_id: timer.outside_lights_hold
 
   - alias: Front Hall Outside lights toggle
     id: front_hall_outside_lights_toggle


### PR DESCRIPTION
Closes #584.

## Why the issue moved

#584 asked for PIR *events* (`event.driveway_pir`) instead of state changes. Those two 433 MHz rfxtrx PIRs are dead and were removed from the config in d1ca7521. Their `event.*` entities logged **no packets at all** across the full recorder window — stronger evidence than the `binary_sensor` silence that commit cited, since an event entity fires on every received packet regardless of state dedup. They are the only motion-related `event` entities on the instance, so there was nothing left to convert there.

The same defect is live in the camera path, which is what this PR fixes.

## The defect

`binary_sensor.<camera>_person_occupancy` is a **level**, not an event — "a person object is being tracked here right now". Frigate's tracker loses and reacquires objects constantly. On 2026-09-03 the driveway sensor went on and off **six times in four minutes** for one visit.

| Old behaviour | Consequence |
|---|---|
| `to: 'on'` state trigger | Doorbell chime on 3 media players + a push notification, once per *reacquisition* rather than once per arrival |
| `to: 'off'` + `for: 300` | A momentary tracking stutter reads as "they left"; lights go off 5 min after *any one* camera clears, even while another still has someone in frame |

## The fix

All three automations now trigger on MQTT `frigate/events` — the same source `automation/camera_snapshot_notification.yaml` already uses — filtering on `payload_json.type` / `after.label` / `after.camera`.

A `timer.outside_lights_hold` helper holds the "lights should be on" state:

- Every person detection on a watched camera restarts it, so the window runs from the **last** detection, across all cameras at once.
- `Outside lights off` triggers on `timer.finished`, and **re-arms** rather than going dark if occupancy shows someone is still there. Occupancy is reliable as a *level* — it is only unreliable as a *trigger*.
- `restore: true`, so a restart mid-hold cannot strand the lights on.

Chime and notification are now **arrival-only**: a `new` event while the hold is not already running. `update` and `end` events extend the hold silently, so a lingering visitor keeps the lights on without re-announcing.

## Trigger set: 5 sensors to 4 cameras

`gates` is dropped. It is a Frigate **zone** on the `driveway_tin_hut` camera (confirmed from the integration's `frigate_config`), so its occupancy was always a subset of a camera already in the list — and `frigate/events` reports `after.camera`, never a zone name, so it could not have matched anyway. `road`, `parking_area_-_driveway` and `parking_area_-_tin_hut` are zones too.

## Dead code removed rather than carried over

- The duplicate `homeassistant.turn_on` of `light.outside_lights` (it appeared twice in the same action).
- The trailing "turn on front floodlights if the house is empty" step. Its condition was `is_state('binary_sensor.home_occupied')` — a one-argument call to a two-argument function, which raises and evaluates false, so **the step never ran**. It was redundant anyway: `light.front_floodlights` is already a member of the `light.outside_lights` group in `lights.yaml`.

## Also

- Notifications identify the camera from the payload instead of the trigger entity's friendly name, and reuse one notification per camera via `tag` + `timeout`, matching the pattern settled in 87bee9d8.
- `mqtt.yaml` gains a `Driveway Tin Hut Last Person` camera. That camera had no snapshot entity, so its notifications previously fell back to the *driveway* image via a substring match on `trigger.entity_id`. `camera_snapshot_notification.yaml` benefits from this too.
- `CLAUDE.md` and `.github/copilot-instructions.md` record the convention, including which sources have no event form (Zigbee occupancy, mmWave presence, ESPHome PIRs) and should stay on state triggers.
- First commit is the separate "Your role" instruction-file change requested alongside this work.

## Deliberately left alone

- `packages/tin_hut.yaml`'s `binary_sensor.tin_hut_occupied` — a template OR of occupancy sensors with `delay_off: 5m`. "Is the tin hut occupied" is genuinely a state question and the level is the right construct.
- Room motion (`packages/kitchen.yaml`, `hallway.yaml`, `ensuite.yaml`, `front_hall.yaml`, `boot_room.yaml`, `garage.yaml`) — zigbee2mqtt and mmWave, no event form available.
- `packages/device_alerts.yaml`'s use of `binary_sensor.front_door_motion` — an availability check, not motion detection.

## Worth a look separately

`outside_person_detected` and `camera_snapshot_notification` now read from the same MQTT topic and overlap almost completely during daylight — both send a person-detected push with a snapshot. Consolidating them is a bigger call than this PR, so it is flagged rather than done.

## Validation

- `yamllint -c .github/yamllint-config.yml` — clean on both changed files.
- `remark ... preset-lint-recommended .` — exit 0.
- HA `check_config` against `homeassistant/home-assistant:stable` — no new errors; the timer parses with `restore: True`, both automations resolve the shared camera-list YAML anchor, and the new MQTT camera registers. Remaining warnings (`alexa_media`, `smartir`, `thermal_comfort`, `adaptive_lighting` not found) are the pre-existing HACS-integration ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a driveway camera view showing the latest person snapshot.
  - Added a hold timer for outside lighting, allowing lights to remain on while activity continues.
  - Added consolidated, time-limited notifications with relevant snapshot images for new person detections.

- **Bug Fixes**
  - Improved outside-light activation to respond to individual detection events rather than sensor state changes.
  - Prevented lights from switching off while occupancy is still detected.
  - Reduced duplicate arrival chimes and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->