### PR TITLE
Reconcile Zaptec charging state instead of pressing on one edge

### DIFF
--- a/packages/zaptec_charging.yaml
+++ b/packages/zaptec_charging.yaml
@@ -107,10 +107,25 @@ template:
         unique_id: zaptec_charging_not_starting
         device_class: problem
         delay_on: "00:15:00"
-        availability: "{{ states('sensor.viewpoint_charger_mode') not in ['unavailable', 'unknown', 'none'] }}"
+        # Deliberately no availability: template. alert: ends an alert on any
+        # state that is not "on" — homeassistant/components/alert/entity.py
+        # makes no exception for unavailable — so letting this sensor go
+        # unavailable would fire done_message and re-arm the whole delay_on.
+        # The charger sensor is cloud-backed and does drop out, and it is most
+        # likely to do so during exactly the kind of trouble worth alerting on.
+        # So hold the last known answer while either source is untrustworthy,
+        # and only move when both can be read. This also stops an unavailable
+        # slot sensor being read as a confident "Predbat does not want to
+        # charge" when the truth is that we cannot tell.
         state: >
-          {{ is_state('binary_sensor.predbat_car_charging_slot', 'on')
-             and is_state('sensor.viewpoint_charger_mode', 'connected_requesting') }}
+          {% set slot = states('binary_sensor.predbat_car_charging_slot') %}
+          {% set mode = states('sensor.viewpoint_charger_mode') %}
+          {% if slot in ['unavailable', 'unknown', 'none']
+                or mode in ['unavailable', 'unknown', 'none'] %}
+            {{ this.state == 'on' }}
+          {% else %}
+            {{ slot == 'on' and mode == 'connected_requesting' }}
+          {% endif %}
 
 alert:
   # The reconciler retries forever and silently succeeds at retrying; this is

--- a/packages/zaptec_charging.yaml
+++ b/packages/zaptec_charging.yaml
@@ -100,23 +100,27 @@ automation:
 template:
   # alert: watches exactly one entity, so the compound "Predbat wants to charge
   # and the car is plugged in but still not charging" condition needs a feeder
-  # sensor. delay_on gives a normal authorization handshake time to complete so
-  # only a genuinely stuck charger trips it.
+  # sensor. It is split in two: the first tracks the condition itself, and the
+  # second turns "still true fifteen minutes later" into the alert state. One
+  # sensor with delay_on cannot do both — see the second sensor for why.
   - binary_sensor:
-      - name: "Zaptec charging not starting"
-        unique_id: zaptec_charging_not_starting
-        device_class: problem
-        delay_on: "00:15:00"
+      - name: "Zaptec charging awaiting authorization"
+        unique_id: zaptec_charging_awaiting_authorization
+        # Asks the same question as the start automation's conditions above, for
+        # a different consumer. The two must change together; nothing enforces
+        # that beyond this comment.
+        #
         # Deliberately no availability: template. alert: ends an alert on any
         # state that is not "on" — homeassistant/components/alert/entity.py
         # makes no exception for unavailable — so letting this sensor go
-        # unavailable would fire done_message and re-arm the whole delay_on.
+        # unavailable would fire done_message and restart the whole wait.
         # The charger sensor is cloud-backed and does drop out, and it is most
         # likely to do so during exactly the kind of trouble worth alerting on.
         # So hold the last known answer while either source is untrustworthy,
-        # and only move when both can be read. This also stops an unavailable
-        # slot sensor being read as a confident "Predbat does not want to
-        # charge" when the truth is that we cannot tell.
+        # and only move when both can be read. Holding also keeps last_changed
+        # still, which is what the sensor below measures. This also stops an
+        # unavailable slot sensor being read as a confident "Predbat does not
+        # want to charge" when the truth is that we cannot tell.
         state: >
           {% set slot = states('binary_sensor.predbat_car_charging_slot') %}
           {% set mode = states('sensor.viewpoint_charger_mode') %}
@@ -126,6 +130,33 @@ template:
           {% else %}
             {{ slot == 'on' and mode == 'connected_requesting' }}
           {% endif %}
+
+      - name: "Zaptec charging not starting"
+        unique_id: zaptec_charging_not_starting
+        device_class: problem
+        # Fifteen minutes of waiting is the alert threshold — long enough that a
+        # normal authorization handshake never trips it.
+        #
+        # Measured from the feeder's last_changed rather than with delay_on,
+        # because delay_on cannot survive a source dropout: template/
+        # binary_sensor.py cancels the pending timer on every re-render and
+        # returns without rescheduling when the new result matches the current
+        # state. A charger sensor flapping more often than every fifteen minutes
+        # would restart the countdown each time and the alert would never fire —
+        # suppressed by exactly the outage it exists to report. last_changed
+        # does not move while the feeder holds its answer, so the clock keeps
+        # running through a dropout.
+        #
+        # now() is bound unconditionally rather than inline: reading it is what
+        # registers this template for the per-minute re-render that advances the
+        # countdown, and Jinja would short-circuit past it while the feeder is
+        # off, leaving nothing to schedule the render that fires the alert.
+        state: >
+          {% set now_ts = now() %}
+          {% set feeder = states.binary_sensor.zaptec_charging_awaiting_authorization %}
+          {{ feeder is not none
+             and feeder.state == 'on'
+             and (now_ts - feeder.last_changed).total_seconds() >= 900 }}
 
 alert:
   # The reconciler retries forever and silently succeeds at retrying; this is

--- a/packages/zaptec_charging.yaml
+++ b/packages/zaptec_charging.yaml
@@ -84,10 +84,15 @@ automation:
         continue_on_error: true
         target:
           entity_id: button.viewpoint_deauthorize_charging
+      # Worded for what the conditions actually guarantee — the car is charging
+      # and no slot is open — rather than "the slot just ended". As a reconciler
+      # this also fires for a session the charger's own schedule started hours
+      # after a slot closed. "Sent" rather than "done" because continue_on_error
+      # means a genuine deauthorization failure reaches this step too.
       - action: notify.mobile_app_nothing_phone_2
         data:
           title: "Zaptec charging"
-          message: "Predbat charging slot ended — charging deauthorized."
+          message: "Charging outside a Predbat slot — deauthorization sent."
           data:
             tag: zaptec_charging
             timeout: 900
@@ -122,7 +127,10 @@ alert:
     skip_first: false
     title: "Zaptec charging"
     message: "Predbat wants to charge and the car is plugged in, but the charger is still not charging."
-    done_message: "Zaptec charging has started."
+    # The feeder sensor clears whenever its compound condition stops holding —
+    # charging started, but equally the slot closed or the car was unplugged.
+    # Only the alert itself can be said to have cleared.
+    done_message: "No longer waiting for Zaptec charging to start."
     notifiers:
       - mobile_app_nothing_phone_2
     data:

--- a/packages/zaptec_charging.yaml
+++ b/packages/zaptec_charging.yaml
@@ -1,32 +1,129 @@
 automation:
   - alias: Zaptec Predbat charging start
     id: zaptec_predbat_charging_start
-    description: Authorize Zaptec charging when Predbat determines it's a good time to charge.
-    trigger:
-      - platform: state
+    description: Authorize Zaptec charging whenever Predbat wants the car charging and the charger is waiting for authorization.
+    triggers:
+      # Fast path: the slot opening with the car already plugged in.
+      - trigger: state
         entity_id: binary_sensor.predbat_car_charging_slot
         to: "on"
-    action:
-      - service: button.press
+      # The car being plugged in after the slot has already opened. Nothing
+      # else notices this — the slot sensor does not change state — so without
+      # this trigger the whole slot is lost waiting for an edge that never comes.
+      - trigger: state
+        entity_id: sensor.viewpoint_charger_mode
+        to: connected_requesting
+      # Safety net for everything neither edge can see: Home Assistant restarting
+      # across the slot transition, the Zaptec cloud being unreachable at the
+      # moment of the press, or the press itself erroring. Re-pressing authorize
+      # is idempotent, so a redundant tick costs nothing.
+      - trigger: time_pattern
+        minutes: "/5"
+    conditions:
+      # Both halves matter. The slot check is the "should it be charging" half;
+      # the charger_mode check is what stops the reconciler pressing authorize
+      # against a charger with no session to authorize — the cause of every
+      # errored run on record, which aborted before the notification could fire.
+      - condition: state
+        entity_id: binary_sensor.predbat_car_charging_slot
+        state: "on"
+      - condition: state
+        entity_id: sensor.viewpoint_charger_mode
+        state: connected_requesting
+    actions:
+      # Deliberately no continue_on_error: if authorizing fails then charging
+      # genuinely did not start, and the error belongs in the trace where the
+      # five-minute retry can be seen working against it.
+      - action: button.press
         target:
           entity_id: button.viewpoint_authorize_charging
-      - service: notify.mobile_app_nothing_phone_2
+      - action: notify.mobile_app_nothing_phone_2
         data:
           title: "Zaptec charging"
-          message: "Predbat charging slot started — charging authorized."
+          message: "Predbat charging slot active — charging authorized."
+          data:
+            # The reconciler can press more than once for a single slot, so a
+            # stable tag updates one notification in place rather than stacking
+            # near-identical ones. Same reuse bound as the camera notifications.
+            tag: zaptec_charging
+            timeout: 900
 
   - alias: Zaptec Predbat charging stop
     id: zaptec_predbat_charging_stop
-    description: Deauthorize Zaptec charging when Predbat's charging slot ends, even mid-session.
-    trigger:
-      - platform: state
+    description: Deauthorize Zaptec charging whenever the car is charging outside a Predbat slot.
+    triggers:
+      # Fast path: the slot closing mid-session.
+      - trigger: state
         entity_id: binary_sensor.predbat_car_charging_slot
         to: "off"
-    action:
-      - service: button.press
+      # Charging that starts outside a slot at all — the charger's own internal
+      # schedule can begin a session with no slot open.
+      - trigger: state
+        entity_id: sensor.viewpoint_charger_mode
+        to: connected_charging
+      # Safety net: a slot that ends while Home Assistant is down otherwise
+      # leaves the car charging at peak rate until the next edge.
+      - trigger: time_pattern
+        minutes: "/5"
+    conditions:
+      - condition: state
+        entity_id: binary_sensor.predbat_car_charging_slot
+        state: "off"
+      # connected_charging only. connected_requesting also covers "plugged in
+      # but not authorized", so including it would press deauthorize every five
+      # minutes for as long as the car sat plugged in outside a slot.
+      - condition: state
+        entity_id: sensor.viewpoint_charger_mode
+        state: connected_charging
+    actions:
+      # continue_on_error here but not on the start side: Zaptec's cloud returns
+      # HTTP 500 for deauthorize_and_stop and the integration raises, even though
+      # the command does its job. Letting that abort the run is why the stop
+      # notification has never once been delivered.
+      - action: button.press
+        continue_on_error: true
         target:
           entity_id: button.viewpoint_deauthorize_charging
-      - service: notify.mobile_app_nothing_phone_2
+      - action: notify.mobile_app_nothing_phone_2
         data:
           title: "Zaptec charging"
           message: "Predbat charging slot ended — charging deauthorized."
+          data:
+            tag: zaptec_charging
+            timeout: 900
+
+template:
+  # alert: watches exactly one entity, so the compound "Predbat wants to charge
+  # and the car is plugged in but still not charging" condition needs a feeder
+  # sensor. delay_on gives a normal authorization handshake time to complete so
+  # only a genuinely stuck charger trips it.
+  - binary_sensor:
+      - name: "Zaptec charging not starting"
+        unique_id: zaptec_charging_not_starting
+        device_class: problem
+        delay_on: "00:15:00"
+        availability: "{{ states('sensor.viewpoint_charger_mode') not in ['unavailable', 'unknown', 'none'] }}"
+        state: >
+          {{ is_state('binary_sensor.predbat_car_charging_slot', 'on')
+             and is_state('sensor.viewpoint_charger_mode', 'connected_requesting') }}
+
+alert:
+  # The reconciler retries forever and silently succeeds at retrying; this is
+  # what makes a persistently failing authorize_charge visible.
+  zaptec_charging_not_starting:
+    name: "Zaptec charging not starting"
+    entity_id: binary_sensor.zaptec_charging_not_starting
+    state: "on"
+    # A real interval is required. repeat: [] passes check_config but raises
+    # IndexError the first time the alert fires.
+    repeat:
+      - 30
+    can_acknowledge: true
+    skip_first: false
+    title: "Zaptec charging"
+    message: "Predbat wants to charge and the car is plugged in, but the charger is still not charging."
+    done_message: "Zaptec charging has started."
+    notifiers:
+      - mobile_app_nothing_phone_2
+    data:
+      tag: zaptec_charging_not_starting


### PR DESCRIPTION
## Problem

Both Zaptec automations pressed their button on a single state edge — slot `on` → authorize, slot `off` → deauthorize. Any ordering that edge didn't anticipate was unrecoverable until the next one. Three failures followed:

- **Car plugged in after the slot opened** — never authorized, because no edge remained to fire. This cost a 12h25m charging slot 0 kWh on 2026-09-05, and had been reproduced on 09-04.
- **Home Assistant restarting across a transition** — the edge happened while nothing was listening.
- **The press erroring and aborting the run** — attempted against a charger with no session to act on, it raised before the notification step, so neither charge nor warning arrived. 4 of 5 stored start traces and **5 of 5** stop traces ended `execution: error`; the stop notification has never once been delivered.

## Change

Both automations become **state reconcilers** rather than edge presses:

- Each keeps its original edge trigger as the fast path, and gains two more: `sensor.viewpoint_charger_mode` changing, and a `time_pattern` `minutes: "/5"` net covering restarts, cloud outages and failed presses.
- Each gains a two-part `condition:` gating the press on both the slot **and** the charger mode. That condition is what stops the press landing on a disconnected charger — the cause of every errored run on record.
- The stop side conditions on `connected_charging` **only**, never `connected_requesting`, which would otherwise deauthorize every five minutes for as long as the car sat plugged in outside a slot.
- Notifications carry a stable `tag` + `timeout: 900`, so a reconciler that presses repeatedly updates one notification rather than stacking.

`continue_on_error` is **asymmetric on purpose**. Zaptec's cloud returns HTTP 500 for `deauthorize_and_stop` and the integration raises even though the command works, so the stop press needs it. The start press does not: a failure there means charging genuinely did not start, and belongs in the trace where the `/5` retry can be seen working against it.

A new `template:` binary_sensor plus an `alert:` cover the case the reconciler *cannot* fix — a persistently failing `authorize_charge` would otherwise retry forever in silence. `delay_on: "00:15:00"` keeps a normal authorization handshake from tripping it; `repeat: [30]` is a real interval (`repeat: []` passes `check_config` but raises `IndexError` on first fire).

Both automations move to modern `triggers:`/`conditions:`/`actions:` syntax while being restructured, and keep their `alias`/`id` so the existing entity registry entries, enable state and trace history survive.

## Validation

- `yamllint -c .github/yamllint-config.yml` over all tracked YAML — clean.
- `check_config` against `homeassistant/home-assistant:stable` — exit 0. The `alert:` entry echoes back with `repeat: [30.0]`, a top-level `title:`, and `data:` carrying only `tag`.

## Deployment note

**A full Home Assistant restart is required, not a config reload.** The repo had no `alert:` top-level key anywhere before this change, so the `alert` component isn't currently loaded and the new alert won't appear without one. The automation and template changes alone would reload fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added monitoring to identify when charging is requested but fails to start.
  - Added an alert for chargers that remain stuck while attempting to begin charging.
  - Added notifications for charging start and stop actions, including automatic timeout handling.

- **Bug Fixes**
  - Improved charging automation reliability by responding to charger and schedule state changes.
  - Added a periodic safety check to help recover when expected state changes are missed.
  - Improved handling when stopping a charging session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->